### PR TITLE
[WIP] Suggestion for how to format FAQ TOC links

### DIFF
--- a/overview/components/FAQTableOfContents.vue
+++ b/overview/components/FAQTableOfContents.vue
@@ -11,98 +11,13 @@
         
       </div>
       <ol class="outerList">
-        
-
-        <!-- Jesse note: below is my initial stab at accessing 
-        the faqList array defined in faq.vue to display as a list
-        instead of hardcoding <li> elements here.
-           
-        I'm still getting familiar with Vue (I'm much more experienced w React)
-        but it seems we need to:
-
-        (1) make most of the content in faq.vue a Component, to render at page /faq
-
-        (2) use some sort of state (which I don't think we have currently set up)
-
-        OR rearrange where FAQTableOfContents renders (it currently renders in the component default.vue)
-        in order to pass array faqList as props from parent component Faq to child component FAQTableOfContents
-            
-        Thoughts?    
-        -->
-
-          <!-- <template
-            v-for="(faq, i) in faqList"
-          >
-              <li :key="i">
-                <p>{{faq.question}}</p>
-              </li>
-          </template> -->
-
-
-        <li class="firstLi">
-          <a href="/faq#who-are-you">Who are you?</a>
-        </li>
-        <li>
-          <a href="/faq#why-do-this">Why are you doing this?</a>
-        </li>
-        <li>
-          <a href="/faq#google-and-apple">Aren’t Google and Apple working on something similar?</a>
-        </li>
-        <li>
-          <a href="/faq#what-is-contact-tracing">What is contact tracing?</a>
-        </li>
-        <li>
-          <a href="/faq#delay-inevitable">If COVID-19 is going to become widespread anyway, why bother delaying the inevitable?</a>
-        </li>
-        <li>
-          <a href="/faq#lockdown-why">There is already a lockdown in my area and we can’t meet other people, so what is the point?</a>
-        </li>
-        <li>
-          <a href="/faq#health-privacy">Is this legal given health data privacy laws?</a>
-        </li>
-        <li>
-          <a href="/faq#traction">Will this app ever get enough traction to work?</a>
-        </li>
-        <li>
-          <a href="/faq#another-app">Is this just another app that will record my symptoms?</a>
-        </li>
-        <li>
-          <a href="/faq#asian-countries">Is this similar to what South Korea, Taiwan, and Singapore are doing?</a>
-        </li>
-        <li>
-          <a href="/faq#hong-kong">Is this the same as what Hong Kong has introduced?</a>
-        </li>
-        <li>
-          <a href="/faq#legal-status">What is the legal status of your organization?</a>
-        </li>
-        <li>
-          <a href="/faq#data-collection">What data are you collecting?</a>
-        </li>
-        <li>
-          <a href="/faq#data-ownership">Who owns the data that is collected and will you sell it?</a>
-        </li>
-        <li>
-          <a href="/faq#bluetooth">Why are you using Bluetooth?</a>
-        </li>
-        <li>
-          <a href="/faq#gps">Why not use GPS as well?</a>
-        </li>
-        <li>
-          <a href="/faq#snoop-dogg">Will this app snoop on me?</a>
-        </li>
-        <li>
-          <a href="/faq#finished">How close to finished is the app?</a>
-        </li>
-        <li>
-          <a href="/faq#exposed">Will this app tell me where or when I was exposed?</a>
-        </li>
-        <li>
-          <a href="/faq#collaborators">Who are your app’s collaborators? Are you working with the government?</a>
-        </li>
-        <li>
-          <a href="/faq#get-involved">How can I get involved?</a>
-        </li>
-        
+        <template
+            v-for="(item, i) in tocItems"
+        >
+            <li :key="i">
+              <a :href="item.link">{{item.title}}</a>
+            </li>
+        </template>
       </ol>
     </div>
   </span>
@@ -174,9 +89,9 @@
 </style>
 
 <script>
-import faqList from "../pages/faq";
-
 export default {
-  faqList
-}
+  props: {
+    tocItems: Array,
+  }
+};
 </script>

--- a/overview/layouts/default.vue
+++ b/overview/layouts/default.vue
@@ -83,29 +83,6 @@
       <TableOfContents></TableOfContents>
     </v-navigation-drawer>
 
-    <!-- Navigation drawer (i.e. Table of Contents) for the FAQ page --->
-    <v-navigation-drawer
-      v-if="$nuxt.$route.name === 'faq'"
-      clipped
-      app
-      :width="350"
-      v-model="tocShow"
-    >
-
-      <v-btn
-        icon
-        small
-        color="primary"
-        class="toc-closer"
-        @click="tocShow = !tocShow"
-      >
-        <v-icon >mdi-close-circle</v-icon>
-      </v-btn>
-
-      <FAQTableOfContents></FAQTableOfContents>
-
-    </v-navigation-drawer>
-
     <v-content>
       <!-- Affiliations --->
       <v-row align="center" justify="center" no-gutters>
@@ -138,17 +115,6 @@
           <v-divider></v-divider>
         </v-col>
       </v-row>
-
-        <!-- Button to show / hide table of contents --->
-      <v-btn
-        v-if="$nuxt.$route.name === 'faq'"
-        class="toc-hamburger"
-        color="primary"
-        v-show="!tocShow"
-        @click="tocShow = !tocShow"
-      >
-        <v-icon>mdi-table-of-contents</v-icon>
-      </v-btn>
 
       <!-- Button to show / hide table of contents --->
       <v-btn
@@ -259,7 +225,6 @@ h1 {
 
 <script>
 import TableOfContents from "~/components/TableOfContents.vue";
-import FAQTableOfContents from "~/components/FAQTableOfContents.vue";
 
 export default {
   data: () => ({
@@ -321,7 +286,6 @@ export default {
   }),
   components: {
     TableOfContents,
-    FAQTableOfContents
   }
 };
 </script>

--- a/overview/pages/faq.vue
+++ b/overview/pages/faq.vue
@@ -1,5 +1,35 @@
 <template>
   <v-container>
+    <!-- Navigation drawer (i.e. Table of Contents) for the FAQ page --->
+    <v-navigation-drawer
+      clipped
+      app
+      :width="350"
+      v-model="tocShow"
+    >
+      <v-btn
+        icon
+        small
+        color="primary"
+        class="toc-closer"
+        @click="tocShow = false"
+      >
+        <v-icon>mdi-close-circle</v-icon>
+      </v-btn>
+
+      <FAQTableOfContents :tocItems="tocItems"></FAQTableOfContents>
+    </v-navigation-drawer>
+
+    <!-- Button to show / hide table of contents --->
+    <v-btn
+      class="toc-hamburger"
+      color="primary"
+      v-show="!tocShow"
+      @click="tocShow = true"
+    >
+      <v-icon>mdi-table-of-contents</v-icon>
+    </v-btn>
+
     <v-row justify="center">
       <v-col cols="12" lg="10">
         <section class="text-content">
@@ -27,7 +57,6 @@
                   <div v-html="faq.response"></div>
 
                   <nuxt-link v-if="faq.linkTitle" :to="faq.nuxtLink">{{faq.linkTitle}}</nuxt-link>
-                  
 
                 </v-card>
               </v-hover>
@@ -37,8 +66,8 @@
           </div>
         </section>
       </v-col>
-    </v-row></v-container
-  >
+    </v-row>
+    </v-container>
 </template>
 
 
@@ -51,8 +80,14 @@
 </style>
 
 <script>
+import FAQTableOfContents from "~/components/FAQTableOfContents.vue";
+
 export default {
+  components: {
+    FAQTableOfContents,
+  },
   data: () => ({
+    tocShow: null,
     faqList: [
       {
         "question": "Who are you?",
@@ -232,6 +267,14 @@ export default {
         "linkTitle": "See our Join Our Team page here for the roles we are looking to fill."
       },
     ]
-  })
+  }),
+  computed: {
+    tocItems() {
+      return this.faqList.map(x => ({
+        title: x.question,
+        link: `/faq#${x.questionId}`,
+      }));
+    }
+  },
 }
 </script>


### PR DESCRIPTION
Went for the option suggested in this comment:

>          OR rearrange where FAQTableOfContents renders (it currently renders in the component default.vue)
>         in order to pass array faqList as props from parent component Faq to child component FAQTableOfContents 

which looks fine to me?

Moving the `v-navigation-drawer` didn't seem to immediately create any alignment issues. Anyway, if you think this looks reasonable, we could probably factor out both TOC into a single component (where each item of the outer list has an optional `innerList` porperty).

We might also be able to put the `v-navigation-drawer` and `v-btn` into the shared `TableOfContents` component.