### PR TITLE
Fail app build on error, cleanup deploy script

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,5 +25,5 @@ jobs:
         CI: true
       run: |
         npm ci
-        npm build
+        npm run generate --fail-on-error
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -27,7 +27,7 @@ jobs:
         CI: true
       run: |
         npm ci
-        npm run generate
+        npm run generate --fail-on-error
 
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1

--- a/overview/scripts/deploy.sh
+++ b/overview/scripts/deploy.sh
@@ -28,13 +28,9 @@ aws s3 mv "$S3_TARGET_URI" "$S3_DEPRECATE_URI" --recursive --only-show-errors
 aws s3 mv "$S3_BUILD_URI" "$S3_TARGET_URI" --recursive --only-show-errors
 aws s3 rm "$S3_DEPRECATE_URI" --recursive --only-show-errors
 
-
-
-if [ ! -z "$CLOUDFRONT_INVALIDATION_ID" ]; then
-   aws cloudfront create-invalidation \
-       --distribution-id $CLOUDFRONT_INVALIDATION_ID \
-       --invalidation-batch "{\"Paths\": {\"Items\": [\"/*\"], \"Quantity\": 1}, \"CallerReference\":\"`date`\"}"
-fi
+aws cloudfront create-invalidation \
+    --distribution-id $CLOUDFRONT_INVALIDATION_ID \
+    --invalidation-batch "{\"Paths\": {\"Items\": [\"/*\"], \"Quantity\": 1}, \"CallerReference\":\"`date`\"}" > /dev/null
 
 echo
 echo Done deploying


### PR DESCRIPTION
Fixed the wrong npm command in the build workflow. Added `--fail-on-error` option to `nuxt generate` which will fail the workflows when an error is encountered. Suppressed cloudfront invalidation logs in the deploy script. 