### PR TITLE
Add new blog page for April 18 progress, plus rearrange dates on /blog

### DIFF
--- a/overview/pages/blog/bluetooth.vue
+++ b/overview/pages/blog/bluetooth.vue
@@ -3,10 +3,10 @@
     <v-row justify="center">
       <v-col cols="12" lg="10">
         <div class="blog-hero">
-          <h1>Bluetooth Primer: 7th of March 2020</h1>
+          <h1>Why we're integrating Bluetooth data into our app</h1>
         </div>
 
-        <h3></h3>
+        <h3>March 7 2020</h3>
 
         <p>
           This project is now roughly two and a half weeks old, and in that time

--- a/overview/pages/blog/index.vue
+++ b/overview/pages/blog/index.vue
@@ -1,23 +1,35 @@
 <template>
   <v-container>
-      <v-row >
-        <v-col class="d-flex justify-end" cols="12" lg="10">
-          <nuxt-link to="/press_releases">Press Releases</nuxt-link>
-        </v-col>
-      </v-row>
-
     <v-row justify="center">
-      <v-col cols="12" lg="10">
+      <v-col cols="12" lg="9">
         <section class="text-content">
           <div class="container">
             <h1>Blog</h1>
             <br>
             <div class="blog-hero">
 
-           
               <div class="blog-item">
                 <div class="blog-item-content">
-                  <h2>Progress Post: 29th of March 2020</h2>
+                  <span class="subtitle">April 18 2020</span>
+                  <h2>You can now see the duration of your contacts, even when the app is in the background</h2>
+                  <p>
+                      The Covid Watch pilot app hit several major milestones in the past 24 hours:
+                      background Temporary Contact Number (<a href="https://github.com/TCNCoalition/TCN#the-tcn-protocol">TCN</a>)
+                      exchange and estimating contact duration and proximity. We are on track to release a
+                      beta version of our app before the end of April.
+                  </p>
+                  <p>
+                      <nuxt-link class="read-more" to="/blog/progressbackground"
+                      >Read More...</nuxt-link
+                      >
+                  </p>
+                </div>
+              </div>
+
+              <div class="blog-item">
+                <div class="blog-item-content">
+                  <span class="subtitle">March 29 2020</span>
+                  <h2>Closed beta testing and other progress</h2>
 
                   <p>
                     Firstly, progress so far:
@@ -42,7 +54,8 @@
 
               <div class="blog-item">
                 <div class="blog-item-content">
-                  <h2>Summary Article: 20th of March 2020</h2>
+                  <span class="subtitle">March 20 2020</span>
+                  <h2>White Paper: Slowing the spread of infectious diseases using crowdsourced data</h2>
 
                   <p>
                     Rather than an ordinary blog post, this is what much of our
@@ -60,7 +73,6 @@
                   </p>
 
                   <p>
-                    This article is current as of the 20th of March, 2020.<br />
                     <nuxt-link class="read-more" to="/article"
                       >Read More...</nuxt-link
                     >
@@ -70,7 +82,8 @@
 
               <div class="blog-item">
                 <div class="blog-item-content">
-                  <h2>Bluetooth Primer: 7th of March 2020</h2>
+                  <span class="subtitle">March 7 2020</span>
+                  <h2>Why we're integrating Bluetooth data into our app</h2>
 
                   <p>
                     This project is now roughly two and a half weeks old, and in
@@ -93,7 +106,8 @@
 
               <div class="blog-item">
                 <div class="blog-item-content">
-                  <h2>Insight Post: 6th of March 2020</h2>
+                  <span class="subtitle">March 6 2020</span>
+                  <h2>Insights from Co-Founder Tina White</h2>
 
                   <p>Welcome to our second insight post!</p>
 
@@ -114,7 +128,8 @@
 
               <div class="blog-item">
                 <div class="blog-item-content">
-                  <h2>Progress Post: 4th of March 2020</h2>
+                  <span class="subtitle">March 4 2020</span>
+                  <h2>GPS-based proof-of-concept and other progress</h2>
 
                   <p>
                     The big news first: we have a proof of concept!<br />
@@ -132,7 +147,8 @@
 
               <div class="blog-item">
                 <div class="blog-item-content">
-                  <h2>Insight Post: 28th of February 2020</h2>
+                  <span class="subtitle">February 28 2020</span>
+                  <h2>Insights from Co-Founder James Petrie</h2>
 
                   <p>
                     Welcome to our first insight post!<br />
@@ -151,7 +167,8 @@
 
               <div class="blog-item">
                 <div class="blog-item-content">
-                  <h2>Progress Post: 27th of February 2020</h2>
+                  <span class="subtitle">February 27 2020</span>
+                  <h2>Progress during our first week</h2>
 
                   <p>
                     Phew! What a week.<br>

--- a/overview/pages/blog/insight1.vue
+++ b/overview/pages/blog/insight1.vue
@@ -3,12 +3,9 @@
     <v-row justify="center">
       <v-col cols="12" lg="10">
         <div class="blog-hero">
-          <!---<img src="images/blog-image.jpg" alt="Full width blog image" /> --->
-          <h1>Insight Post: 28th of February 2020</h1>
+          <h1>Insights from Co-Founder James Petrie</h1>
         </div>
-        <h3>
-          An Inside View
-        </h3>
+        <h3>February 28 2020</h3>
         <p>
           Welcome to our first insight post!<br /><br />
           In this series, our researchers will share what they're currently

--- a/overview/pages/blog/insight2.vue
+++ b/overview/pages/blog/insight2.vue
@@ -3,10 +3,10 @@
     <v-row justify="center">
       <v-col cols="12" lg="10">
         <div class="blog-hero">
-          <h1>Insight Post: 6th of March 2020</h1>
+          <h1>Insights from Co-Founder Tina White</h1>
         </div>
 
-        <h3>An Inside View</h3>
+        <h3>March 7 2020</h3>
 
         <p>
           Welcome to our first insight post!<br />

--- a/overview/pages/blog/progress1.vue
+++ b/overview/pages/blog/progress1.vue
@@ -4,10 +4,10 @@
       <v-col cols="12" lg="10">
         <div class="blog-hero">
           <!--- <img src="images/blog-image.jpg" alt="Full width blog image" />-->
-          <h1>Progress Post: 27th of February 2020</h1>
+          <h1>Progress during our first week</h1>
         </div>
 
-        <h3>A busy start</h3>
+        <h3>February 27 2020</h3>
 
         <p>
           Phew! What a week.<br />

--- a/overview/pages/blog/progress2.vue
+++ b/overview/pages/blog/progress2.vue
@@ -4,10 +4,10 @@
       <v-col cols="12" lg="10">
         <div class="blog-hero">
           <!--- <img src="images/blog-image.jpg" alt="Full width blog image" />-->
-          <h1>Progress Post: 4th of March 2020</h1>
+          <h1>GPS-based proof-of-concept and other progress</h1>
         </div>
 
-        <h3>Proof and Challenges</h3>
+        <h3>March 4 2020</h3>
 
         <p>
           The big news first: we have a proof of concept!&nbsp; It takes

--- a/overview/pages/blog/progress3.vue
+++ b/overview/pages/blog/progress3.vue
@@ -4,11 +4,11 @@
       <v-col cols="12" lg="10">
         <div class="blog-hero">
           <!--- <img src="images/blog-image.jpg" alt="Full width blog image" />-->
-          <h1>Progress Post: 29th of March 2020</h1>
+          <h1>Closed beta testing and other progress</h1>
           <br>
         </div>
 
-        <h3>Collaboration and Contrast</h3>
+        <h3>March 29 2020</h3>
         <br>
         <p>
           Firstly, progress so far:
@@ -19,6 +19,8 @@
           with multiple health agencies and other groups across the world about implementing our Bluetooth
           contact tracing system.
         </p>
+
+        <h3>Collaboration and Contrast</h3>
 
         <p>
           Secondly, as our team has grown and we’ve reached out to connections across the tech world,

--- a/overview/pages/blog/progressbackground.vue
+++ b/overview/pages/blog/progressbackground.vue
@@ -1,0 +1,155 @@
+<template>
+  <v-container>
+    <v-row justify="center">
+      <v-col cols="12" lg="10">
+        <div class="blog-hero">
+          <h1>You can now see the duration of your contacts, even when the app is in the background</h1>
+        </div>
+
+        <h3>April 18 2020</h3>
+
+        <p>
+            The Covid Watch pilot app hit several major milestones in the past 24 hours:
+            background Temporary Contact Number (<a href="https://github.com/TCNCoalition/TCN#the-tcn-protocol">TCN</a>)
+            exchange and estimating contact duration and proximity. We are on track to release a
+            beta version of our app before the end of April.
+        </p>
+        <p>
+            Many existing contact tracing apps, such as Singapore’s TraceTogether,
+            <a href="https://tracetogether.zendesk.com/hc/en-sg/articles/360044846854-Does-TraceTogether-need-to-be-in-the-foreground-to-work-Can-I-use-other-apps-">
+            have required</a> that iOS users keep their app running in the foreground. Covid
+            Watch has identified and proven a method for detecting contact events between phones
+            passively, with no action required by the user.
+        </p>
+        <p>
+            This means that our users will be alerted to exposures that happen while they are
+            riding the bus, talking on the phone, or otherwise not directly engaged with the app.
+            We think this greatly increases our chances of detecting a large enough proportion of
+            contacts to reduce the spread of COVID-19.
+        </p>
+
+        <h2>Technical Details</h2>
+        <h3>Background TCN exchange between iOS devices</h3>
+        <p>
+            At present, iOS prevents third-party apps to use broadcast-oriented advertising of
+            their data while in the background. We have found a way to bridge communication
+            between iOS devices using nearby Android devices, without significantly affecting
+            battery life.
+        </p>
+        <p>
+            Here are the details on how TCNs will be shared between different devices:
+        </p>
+          <v-simple-table class="ma-2">
+            <template v-slot:default>
+            <thead>
+                <tr>
+                <th class="text-left">Listener App</th>
+                <th class="text-left">Sender App</th>
+                <th class="text-left">TCN Communication</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>Android</td>
+                    <td>Android</td>
+                    <td>The Sender broadcasts TCN over Bluetooth. The Listener observes this broadcast directly.</td>
+                </tr>
+                <tr>
+                    <td>iOS</td>
+                    <td>Android</td>
+                    <td>Same as row above.</td>
+                </tr>
+                <tr>
+                    <td>Android</td>
+                    <td>iOS</td>
+                    <td>
+                        The Listener signals availability as a Bluetooth “peripheral”. The Sender,
+                        acting as a Bluetooth “central”, connects to this “peripheral” and writes
+                        its TCN to a field exposed by the peripheral then disconnects.
+                    </td>
+                </tr>
+                <tr>
+                    <td>iOS (background)</td>
+                    <td>iOS (foreground)</td>
+                    <td>
+                        The Listener acts as a Bluetooth “central”. It connects to the Sender and
+                        reads the TCN from the field exposed by the “peripheral”, then disconnects.
+                    </td>
+                </tr>
+                <tr>
+                    <td>iOS (foreground)</td>
+                    <td>iOS (background)</td>
+                    <td>Same as row above.</td>
+                </tr>
+                <tr>
+                    <td>iOS (background)</td>
+                    <td>iOS (background)</td>
+                    <td>
+                        A nearby Android device acts as a bridge. It receives TCNs through “central”
+                        write operations (see 3rd row above) and adds them to a rotating list to
+                        broadcast alongside its own TCN.
+                    </td>
+                </tr>
+            </tbody>
+            </template>
+        </v-simple-table>
+        <p>
+            With Apple’s contact tracing API, which will be released in May (see our related
+            <nuxt-link to="/press_releases/google_apple_press_release">press release</nuxt-link>),
+            this bridging may no longer be necessary, but we cannot afford to lose the
+            intervening weeks; an earlier deployment may save lives. If you would like to make use
+            of our bridging implementation in your own project, you can find it in our Github repos
+            for our iOS Pilot and Android Pilot apps.
+        </p>
+
+        <h3>Estimating contact duration and proximity</h3>
+        <p>
+            Both of these statistics are crucial for evaluating the risk of exposure.
+        </p>
+        <p>
+            The CDC's <a href="https://www.cdc.gov/coronavirus/2019-ncov/php/public-health-recommendations.html">
+            Public Health Recommendations for Community-Related Exposure</a> describe a need to
+            self isolate after "close contact (less than 6 feet) for a prolonged period of time"
+            with someone experiencing COVID-19 symptoms. Though a precise definition of "a
+            prolonged period of time" isn’t yet established, we expect users might wish to take
+            different actions based on a 15 minute or 3-hour exposure event. 
+        </p>
+        <p>
+            We can estimate duration because each user generates TCNs using a shared seed and a
+            secret key. We rotate TCNs on a short interval to prevent users from being tracked by
+            someone listening to what their phone broadcasts. This means that a listener might see
+            three or four different numbers for a single contact event.
+        </p>
+        <p>
+            When a diagnosed user chooses to upload their data to our server, we’ll generate
+            associations between each TCN that user had broadcast while infectious, allowing us to
+            cluster together sequential broadcasts. The app will then be able to estimate exposure
+            duration when it notifies users.
+        </p>
+        <p>
+            Proximity is estimated every time TCNs are exchanged, based on a Bluetooth metric called
+            RSSI (Received Signal Strength Indication), which is the method of estimating proximity
+            <a href="https://www.bluetooth.com/blog/proximity-and-rssi/">recommended</a> by the
+            Bluetooth Special Interest Group.
+        </p>
+        
+        <h2>Learn More</h2>
+        <p>
+            Covid Watch is an open source project. You can follow our progress across many Github repos:
+        </p>
+        <ul>
+            <li><a href="https://github.com/covid19risk/covidwatch-ios-pilot">Covid Watch iOS Pilot App</a></li>
+            <li><a href="https://github.com/covid19risk/covidwatch-android-pilot">Covid Watch Android Pilot App</a></li>
+            <li><a href="https://github.com/TCNCoalition/tcn-client-ios">TCN Protocol Client for iOS</a></li>
+            <li><a href="https://github.com/TCNCoalition/tcn-client-android">TCN Protocol Client for Android</a></li>
+        </ul>
+        <p> 
+            You can also see <a href="https://www.youtube.com/watch?v=L3KZIs4PHXs&feature=youtu.be">a
+            demonstration of this technology</a> on the Youtube channel of Zsombor Szabo, Covid Watch
+            co-founder and Head of Engineering. If you have questions, you can always get in touch
+            with us at <a href="mailto:contact@covid-watch.org">contact@covid-watch.org</a>.
+        </p>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>

--- a/overview/pages/medialist.vue
+++ b/overview/pages/medialist.vue
@@ -2,7 +2,7 @@
   <v-container class="mediaList">
     <v-row >
       <v-col class="d-flex justify-end" cols="12" lg="10">
-        <span class="title"><nuxt-link to="/press_releases">Press Releases</nuxt-link></span>
+        <nuxt-link to="/press_releases">Press Releases</nuxt-link>
       </v-col>
     </v-row>
     <v-row justify="center">
@@ -54,10 +54,12 @@
 
 <script>
   import SubscribeForm from '../components/SubscribeForm.vue'
+  import PageFeed from '../components/PageFeed.vue'
 
   export default {
     components: {
-      SubscribeForm
+      SubscribeForm,
+      PageFeed
     },
     data: () => ({
       mediaList: [

--- a/overview/pages/medialist.vue
+++ b/overview/pages/medialist.vue
@@ -2,7 +2,7 @@
   <v-container class="mediaList">
     <v-row >
       <v-col class="d-flex justify-end" cols="12" lg="10">
-        <nuxt-link to="/press_releases">Press Releases</nuxt-link>
+        <span class="title"><nuxt-link to="/press_releases">Press Releases</nuxt-link></span>
       </v-col>
     </v-row>
     <v-row justify="center">
@@ -54,12 +54,10 @@
 
 <script>
   import SubscribeForm from '../components/SubscribeForm.vue'
-  import PageFeed from '../components/PageFeed.vue'
 
   export default {
     components: {
-      SubscribeForm,
-      PageFeed
+      SubscribeForm
     },
     data: () => ({
       mediaList: [


### PR DESCRIPTION
Adding blog post, which has been approved in Google doc form. I will make more changes to related pages tomorrow (see below) but there seemed to be urgency around releasing this specific content.

I did change our blog feed to be a bit more bloglike (i.e. gave all the posts individual titles).

## Screenshots
![image](https://user-images.githubusercontent.com/7595169/79681653-b77fad00-81d0-11ea-94c0-66e5be4c58bf.png)

![image](https://user-images.githubusercontent.com/7595169/79681657-c0707e80-81d0-11ea-9472-bbed92392b9d.png)


## Notes

There are more changes I'd like to make here, listed somewhat in the order of difficulty:
* Use a single shared component (which I already have drafted) for our lists of press releases, media mentions, and blog posts
* Remove 'Blog' and 'Media' from the top navbar and replace with a single 'Latest' or 'Updates' page
* Style the pages for all of those kinds of content to be more readable (larger line height, smaller line width, more padding in general- we are not in any way following [web typography conventions](https://kickpoint.ca/the-readability-formula-making-your-website-easy-to-read/) right now)
* Stop managing our blog posts and press releases as individual Vue files, and instead use Jekyll or Ghost or some kind of templating language, anything that would save me from having to type individual `<p></p>` tags, but ideally something that would actually track publication dates itself