### PR TITLE
Always scroll to top, less whitespace around page conatiner

### DIFF
--- a/app/router.scrollBehavior.js
+++ b/app/router.scrollBehavior.js
@@ -1,0 +1,5 @@
+// Override default scroll behaviour, forcing the scroll position to the top for every route
+// https://nuxtjs.org/api/configuration-router#scrollbehavior
+export default function(to, from, savedPosition) {
+  return { x: 0, y: 0 };
+}

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -25,12 +25,16 @@
   &#main-content {
     padding-top: 0px;
     padding-bottom: 0px;
+
+    div:first-of-type {
+      padding-top: 0px;
+      padding-bottom: 0px;
+    }
   }
 }
 
 // this manages the transitions between pages.
 // more info/options we can play with: https://www.vuemastery.com/courses/animating-vue/page-transitions
-
 .slide-fade-enter {
   transform: translateX(10px);
   opacity: 0;

--- a/pages/faq.vue
+++ b/pages/faq.vue
@@ -104,7 +104,6 @@
     </v-row>
 
 
-      <!-- there is white space at below the Newsletter caused by v-container padding.  Perhaps adjust this to not have padding on bottom? -->
       <!-- Newsletter -->
       <Newsletter></Newsletter>
 

--- a/pages/how-it-works.vue
+++ b/pages/how-it-works.vue
@@ -15,7 +15,6 @@
                     </div>
                 </v-col>
 
-                <!-- <v-spacer></v-spacer> -->
                 <v-col :md="4">
                     <img class="connected_img" src="../assets/how_it_works/connected_group_final.svg">
                 </v-col>
@@ -88,7 +87,7 @@
                
             </v-row>
 
-            <v-row>
+            <v-row class="no-gutters">
                 <v-spacer></v-spacer>
                 <v-col :md="4" :sm="8">
                     <img class="woman-triangle" src="../assets/how_it_works/woman-triangle.svg">

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -180,7 +180,7 @@
       // hacky way to get whitepaper button to not take up margin on right of screen
       .cta-whitepaper {
         display: flex;
-        justify-content: start;
+        justify-content: flex-start;
         width: 160px;
       }
   }


### PR DESCRIPTION
Addresses 2 Trello tickets.

### Moving between pages doesn't load the top of the page navigated to
Previous state:
![image](https://user-images.githubusercontent.com/7595169/80786376-4c22cd00-8b38-11ea-9991-1ca81c8434b0.png)

Now it does! (That said, I haven't tested how this interacts with mid-page anchors yet.)

### Some element's padding at bottom makes white space between footer and page content
Previous state:
![image](https://user-images.githubusercontent.com/7595169/80786410-6c528c00-8b38-11ea-92b7-662bfc2d582f.png)

Current state:
![image](https://user-images.githubusercontent.com/7595169/80786351-37463980-8b38-11ea-8966-303304b6deef.png)

There's still a bit of space at the bottom of the FAQ page, I think related to the aspect ratio of the image not matching the size of the column it's in?