### PR TITLE
fix about cta button

### DIFF
--- a/pages/about.vue
+++ b/pages/about.vue
@@ -198,6 +198,13 @@
 </template>
 
 <style lang="scss">
+@media (max-width: 400px){
+  .we_value_img{
+     max-width: 260px;
+  }
+}
+
+
 @media (max-width: 1000px) {
   .earth_img {
     display: none;


### PR DESCRIPTION
Makes it so the CTA button on `about` doesn't go off the screen for mobile devices. This was a svg issue (of course), fixed by enforcing a max-width on small screen sizes

## Previously (iphone XE size)
![DeepinScreenshot_select-area_20200503142858](https://user-images.githubusercontent.com/20446774/80926205-8fed2080-8d4a-11ea-80f4-3d404d112b6d.png)

## Now
![DeepinScreenshot_select-area_20200503142845](https://user-images.githubusercontent.com/20446774/80926203-8cf23000-8d4a-11ea-9844-8ac98d78a44e.png)


