### PR TITLE
News cards are well-behaved, never overlap each other

### DIFF
--- a/components/NewsCard.vue
+++ b/components/NewsCard.vue
@@ -25,7 +25,7 @@
           />
         </a>
       </div>
-      <div class="primary--text grow float-right">
+      <div class="primary--text body-2 grow float-right mb-2">
         <span style="font-style: italic;">- {{ card.outlet_name }}</span>
       </div>
     </div>

--- a/components/NewsCard.vue
+++ b/components/NewsCard.vue
@@ -4,8 +4,6 @@
       :src="card.type === 'press_release' ? press.stripe : news.stripe"
       min-width="100%"
       :gradient="card.type === 'press_release' ? press.gradient : news.gradient"
-      cover
-      position="left"
     />
     <div class="d-flex py-6 px-6 justify-space-between">
       <img :src="card.type === 'press_release' ? press.icon : news.icon" />

--- a/components/NewsCard.vue
+++ b/components/NewsCard.vue
@@ -1,22 +1,14 @@
 <template>
   <v-card :card="card" class="news-card">
-    <img
-      v-if="card.type === 'press_mention'"
-      class="stripe"
-      style="position: absolute;"
-      src="../assets/home_page/news_cards_top_accent.svg"
-      alt="stripe"
-    />
-    <img
-      v-if="card.type === 'press_release'"
-      class="stripe"
-      style="position: absolute;"
-      src="../assets/home_page/tangerine_stripe.svg"
-      alt="stripe"
+    <v-img
+      :src="card.type === 'press_release' ? press.stripe : news.stripe"
+      min-width="100%"
+      :gradient="card.type === 'press_release' ? press.gradient : news.gradient"
+      cover
+      position="left"
     />
     <div class="d-flex py-6 px-6 justify-space-between">
-      <img v-if="card.type === 'press_mention'" src="../assets/home_page/news_icon.svg" alt="news" />
-      <img v-if="card.type === 'press_release'" src="../assets/home_page/tangerine_news_icon.svg" alt="news" />
+      <img :src="card.type === 'press_release' ? press.icon : news.icon" />
       <div class="news-date">{{ card.date }}</div>
     </div>
     <div class="px-6 mt-4">
@@ -26,45 +18,32 @@
           :href="card.url"
           class="primary--text"
           style="text-decoration: none; font-weight: bold;"
-          >{{ card.title }}
+        >
+          {{ card.title }}
           <img
             style="height: 10px;"
             src="../assets/home_page/arrow_icon.svg"
             alt="arrow"
-        /></a>
+          />
+        </a>
       </div>
       <div class="primary--text grow float-right">
-        <span style="font-style: italic;">- {{ card.outlet_name }} </span>
+        <span style="font-style: italic;">- {{ card.outlet_name }}</span>
       </div>
     </div>
-
     <slot></slot>
   </v-card>
 </template>
 
 <style lang="scss" scoped>
 .news-card {
-  height: 230px;
-  min-width: 320px;
+  height: 100%;
+  max-width: 100%;
 }
 
 .card_title {
   min-height: 80px;
 }
-
-//     @media (max-width:400px){
-//         .news-card {
-//         height: 250px;
-//         min-width: 320px;
-//         }
-//     }
-
-//   @media (min-width:400px){
-//       .news-card {
-//         height: 350px;
-//         min-width: 300px;
-//     }
-//   }
 </style>
 
 <script>
@@ -72,6 +51,18 @@ export default {
   name: "NewsCard",
   props: {
     card: Object
-  }
+  },
+  data: () => ({
+    news: {
+      icon: require("../assets/home_page/news_icon.svg"),
+      stripe: require("../assets/home_page/news_cards_top_accent.svg"),
+      gradient: "to right, #43C4D9, #fff" // aqua
+    },
+    press: {
+      icon: require("../assets/home_page/tangerine_news_icon.svg"),
+      stripe: require("../assets/home_page/tangerine_stripe.svg"),
+      gradient: "to right, #F05452, #fff" // tangerine
+    }
+  })
 };
 </script>

--- a/components/NewsCard.vue
+++ b/components/NewsCard.vue
@@ -17,12 +17,8 @@
           class="primary--text"
           style="text-decoration: none; font-weight: bold;"
         >
-          {{ card.title }}
-          <img
-            style="height: 10px;"
-            src="../assets/home_page/arrow_icon.svg"
-            alt="arrow"
-          />
+          {{ card.title }}&nbsp;
+          <img style="height: 10px;" src="../assets/home_page/arrow_icon.svg" alt="arrow" />
         </a>
       </div>
       <div class="primary--text body-2 grow float-right mb-2">

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -111,15 +111,6 @@
 <style lang="scss">
 #home {
   @media (max-width: 400px) {
-    .news-card {
-      height: 260px;
-      min-width: 220px;
-
-      .stripe {
-        width: 220px;
-      }
-    }
-
     // hacky way to get whitepaper button to not take up margin on right of screen
     .cta-whitepaper {
       display: flex;
@@ -129,15 +120,6 @@
   }
 
   @media (min-width: 400px) {
-    .news-card {
-      height: 250px;
-      min-width: 320px;
-
-      .stripe {
-        width: 320px;
-      }
-    }
-
     // hacky way to get whitepaper button to center
     .cta-whitepaper {
       display: flex;


### PR DESCRIPTION
### Summary
This was mostly a matter of removing hardcoded widths.

After I did this, I saw this weird thing where the stripe would end up not reaching the edge of the card. I could not figure out why this was, so I just... added a linear gradient on top of it.

tbh we could probably just have a linear gradient, without any SVGs, but I decided I should figure out the app bar before noodling around with that.

### Screenshots
Inexplicable whitespace:
![why is there this whitespace](https://user-images.githubusercontent.com/7595169/80927855-6f769380-8d55-11ea-9fbe-b9746f2bf27e.png)

Eliminated with the help of a linear gradient:
![I guess it's gone now](https://user-images.githubusercontent.com/7595169/80927923-e0b64680-8d55-11ea-9b2d-fe6d35879587.png)
