### PR TITLE
Fix footer broken link

### DIFF
--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -6,11 +6,16 @@
           <b>{{ section.title }}</b>
           <v-list class="footer-link-list" dense>
             <v-list-item v-for="link in section.links" :key="link.title" class="pl-0">
-              <nuxt-link class="link" :to="link.href">
+              <nuxt-link v-if="link.title !== 'Contact Us'" class="link" :to="link.href">
                 {{
                 link.title
                 }}
               </nuxt-link>
+              <a v-else :href="link.href">
+                  {{
+                  link.title
+                  }}
+              </a>
             </v-list-item>
           </v-list>
         </v-col>


### PR DESCRIPTION
Makes the `Contact Us` link in the Footer not go to 404. It just needed to be an anchor tag.