### PR TITLE
add basic article page

### DIFF
--- a/pages/article.vue
+++ b/pages/article.vue
@@ -1,0 +1,33 @@
+<template>
+ <v-container grid-list-xs> 
+    <v-row id="article">
+      <!-- First row-->
+      <v-row :class="pageSectionClass">
+        <v-col cols="12" :md="12">
+            <div class="mb-12">
+                <h1 class="mb-5">Read our Whitepaper</h1>
+
+                <div class="subtitle">
+                    <p>
+                        Read our foundational whitepaper proposing the Covid Watch solution in detail.  Published March 20, 2020.
+                    </p>
+                </div>
+            </div>
+        </v-col>
+      </v-row>
+    </v-row>
+    <CTA pdf content="Read the Whitepaper" href="/covid_watch_whitepaper.pdf"></CTA>
+ </v-container>
+</template>
+
+<script>
+import Button from "../components/Button.vue";
+import CTA from "../components/CTA.vue";
+
+export default {
+    components: {
+        Button,
+        CTA,
+    }
+}
+</script>


### PR DESCRIPTION
I noticed many users landing on /article based on previously shared links.  This goes to a 404 page.  That's not good, this is a very simple page to deliver the content the users are probably looking for: the whitepaper

![Screen Shot 2020-05-08 at 9 05 31 PM](https://user-images.githubusercontent.com/16062590/81459821-ad1d5700-916f-11ea-893e-19a602e9255d.png)
