### PR TITLE
Only show one mobile screenshot on xs

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -92,7 +92,7 @@
 
           <v-col
             class="mx-md-4"
-            v-for="(img, i) in mobileImages"
+            v-for="(img, i) in mobileImagesToShow"
             :key="i"
             :md="2"
             :sm="4"
@@ -108,7 +108,6 @@
 
 <style lang="scss">
 #home {
-  
   @media (min-width: 960px) {
     .mobile_imgs {
       background-image: url("../assets/home_page/mobile_background.svg");
@@ -123,7 +122,6 @@
       width: 280px;
     }
   }
-
 
   @media (max-width: 760px) {
     #hero {
@@ -154,9 +152,6 @@
       }
     }
 
-
-
-
     @media (min-width: 1760px) {
       #hero {
         height: 570px;
@@ -169,8 +164,8 @@
       }
 
       #how-it-works {
-          margin-top: -4vw;
-        }
+        margin-top: -4vw;
+      }
     }
   }
 
@@ -213,6 +208,13 @@ export default {
   methods: {
     hideBackground(e) {
       // debugger
+    }
+  },
+  computed: {
+    mobileImagesToShow() {
+      return this.$vuetify.breakpoint.xsOnly
+        ? [this.mobileImages[0]]
+        : this.mobileImages;
     }
   },
   data: () => ({
@@ -263,11 +265,13 @@ export default {
       }
     ],
     newsCards: [
-        {
+      {
         type: "press_release",
         date: "May 7, 2020",
-        title: "Emergent Ventures singles out the Covid Watch app for coronavirus response",
-        url: "https://drive.google.com/file/d/1uVVPVzwUnBhqeOQU4Vw9O-Sng77uNzmt/view",
+        title:
+          "Emergent Ventures singles out the Covid Watch app for coronavirus response",
+        url:
+          "https://drive.google.com/file/d/1uVVPVzwUnBhqeOQU4Vw9O-Sng77uNzmt/view",
         author_name: "",
         outlet_name: "Press Release, Covid Watch"
       },
@@ -275,15 +279,18 @@ export default {
         type: "press_mention",
         date: "May 6, 2020",
         title: "This App Protects Privacy While Tracing Covid-19 Infections",
-        url: "https://reason.com/podcast/this-app-protects-privacy-while-tracing-covid-19-infections/",
+        url:
+          "https://reason.com/podcast/this-app-protects-privacy-while-tracing-covid-19-infections/",
         author_name: "",
         outlet_name: "Reason Magazine"
       },
       {
         type: "press_mention",
         date: "April 8, 2020",
-        title: "Clever Cryptography Could Protect Privacy in Covid-19 Contact Tracing Apps",
-        url: "https://www.wired.com/story/covid-19-contact-tracing-apps-cryptography/",
+        title:
+          "Clever Cryptography Could Protect Privacy in Covid-19 Contact Tracing Apps",
+        url:
+          "https://www.wired.com/story/covid-19-contact-tracing-apps-cryptography/",
         author_name: "",
         outlet_name: "Wired"
       }


### PR DESCRIPTION
I felt like it was weird to scroll through three large mobile screenshots to get to the footer on the mobile index page. Now this only shows one!

![image](https://user-images.githubusercontent.com/7595169/81488189-76504b00-921a-11ea-9e59-7e2db9842412.png)
