### PR TITLE
Update airtable workflow to auto-merge

### DIFF
--- a/.github/workflows/airtable.yaml
+++ b/.github/workflows/airtable.yaml
@@ -13,6 +13,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+     - name: Create hotfix branch
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "octocat"
+          git checkout -b "auto-add-news"
+
       - name: Run airtable script
         env:
           AIRTABLE_BASE_KEY: ${{ secrets.AIRTABLE_BASE_KEY }}
@@ -23,9 +29,17 @@ jobs:
           chmod +x airtable-auto.py
           ./airtable-auto.py
           
-      - name: Create Pull Request
-        uses: colbymorrison/create-pull-request@v2
-        with:
-          commit-message: "auto-add new news"
-          title: "Airtable GitHub action -- Update News"
-          body: "New News from Airtable"
+      - name: Update master and prod
+        run: |
+          git fetch --all
+
+          git add assets/data/medialist.json
+          git commit -m "auto update news from airtable"
+
+          git checkout master
+          # Only update medialist.json 
+          git checkout auto-add-news assets/data/medialist.json
+          git commit -m "auto update news from airtable"
+          git push origin master
+
+          git branch -D auto-add-news

--- a/.github/workflows/airtable.yaml
+++ b/.github/workflows/airtable.yaml
@@ -1,5 +1,3 @@
-# copied directly from Colby's previous work:  https://github.com/covid19risk/legacy_website/blob/12ebd1324c1c03bdab90c9522ecabbf6f9e53014/.github/workflows/airtable.yaml
-
 name: Airtable
 
 on:
@@ -39,7 +37,7 @@ jobs:
           git checkout master
           # Only update medialist.json 
           git checkout auto-add-news assets/data/medialist.json
-          git commit -m "auto update news from airtable"
+          git diff-index --quiet HEAD -- || git commit -m "auto update news from airtable"
           git push origin master
 
           git branch -D auto-add-news


### PR DESCRIPTION
The Airtable workflow now does not create a pull request, it commits new changes automatically. When run, the workflow creates a new branch from `master` called `auto-add-news`

It runs the airtable script and creates a commit in `auto-add-news` with the updated `medialist.json` file.

It then checks out master and merges only `medialist.json` from the `auto-add-news` branch, so we make sure that only `medialist.json` can be affected by this workflow.

To make this work for prod as well, we can just copy lines 39-43, but with the prod branch.

NOTE: The workflow will fail if there are no changes to the media list as it will attempt to commit when no files have changed. 