### PR TITLE
Revert airtable action to auto-create PR

### DIFF
--- a/.github/workflows/airtable.yaml
+++ b/.github/workflows/airtable.yaml
@@ -1,3 +1,5 @@
+# copied directly from Colby's previous work:  https://github.com/covid19risk/legacy_website/blob/12ebd1324c1c03bdab90c9522ecabbf6f9e53014/.github/workflows/airtable.yaml
+
 name: Airtable
 
 on:
@@ -11,12 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Create hotfix branch
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "octocat"
-          git checkout -b "auto-add-news"
-
       - name: Run airtable script
         env:
           AIRTABLE_BASE_KEY: ${{ secrets.AIRTABLE_BASE_KEY }}
@@ -27,17 +23,9 @@ jobs:
           chmod +x airtable-auto.py
           ./airtable-auto.py
           
-      - name: Update master and prod
-        run: |
-          git fetch --all
-
-          git add assets/data/medialist.json
-          git commit -m "auto update news from airtable"
-
-          git checkout master
-          # Only update medialist.json 
-          git checkout auto-add-news assets/data/medialist.json
-          git diff-index --quiet HEAD -- || git commit -m "auto update news from airtable"
-          git push origin master
-
-          git branch -D auto-add-news
+      - name: Create Pull Request
+        uses: colbymorrison/create-pull-request@v2
+        with:
+          commit-message: "auto-add new news"
+          title: "Airtable GitHub action -- Update News"
+          body: "New News from Airtable"


### PR DESCRIPTION
@alexanian adding context here: this was breaking because we've protected the master branch, so we can't auto-create a PR.

![image](https://user-images.githubusercontent.com/7595169/81768192-3b0a8200-948f-11ea-8559-02f9c58eb762.png)
