### PR TITLE
Adjust advisors

### DIFF
--- a/pages/about.vue
+++ b/pages/about.vue
@@ -338,35 +338,65 @@ export default {
     ],
     advisers: [
       {
-        name: "Dan Boneh",
-        description: "Professor of Computer Science and Electrical Engineering at Stanford University.",
+        name: "Charles Belle, JD",
+        description: "Fellow at Center for Internet and Society at Stanford Law School.",
+        link: 'http://cyberlaw.stanford.edu/about/people/charles-belle'
+      },
+      {
+        name: "Dan Boneh, PhD",
+        description: "Professor of Computer Science and Electrical Engineering, Stanford University",
         link: 'https://profiles.stanford.edu/dan-boneh'
       },
       {
-        name: "Joshua Cohen",
-        description: "Faculty at Apple University; Distinguished Senior Fellow at UC Berkeley; Editor at Boston Review.",
+        name: "Joshua Cohen, PhD",
+        description: "Faculty at Apple University; Distinguished Senior Fellow at UC Berkeley; Editor, Boston Review",
         link: 'http://bostonreview.net/joshua-cohen'
       },
       {
-        name: "Al Gidari",
-        description: "Director of Privacy at Center for Internet and Society, Stanford Law School.",
+        name: "Jeremy Fiddler",
+        description: "Principal, Zygote Ventures",
+        link: 'http://zygoteventures.com/about-the-principal/'
+      },
+      {
+        name: "Al Gidari, JD",
+        description: "Director of Privacy at Center for Internet and Society, Stanford Law School",
         link: 'http://cyberlaw.stanford.edu/about/people/albert-gidari'
       },
       {
-        name: "Dr. Plinio Pelegrini Morita",
-        description: "Assistant Professor and J.W. Graham Information Technology Emerging Leader Chair in Applied Health Informatics at University of Waterloo, Canada.",
+        name: "Robert M. Grant, MD, MPH",
+        description: "MPH Professor of Medicine, University of California San Francisco",
+        link: 'https://profiles.ucsf.edu/robert.grant'
+      },
+      {
+        name: "Jeffrey Landish",
+        description: "Security Consultant, Gordian Research",
+        link: 'https://jeffreyladish.com/'
+      },
+      {
+        name: "Plinio Pelegrini Morita, PhD",
+        description: "Assistant Professor and J.W. Graham Information Technology Emerging Leader Chair in Applied Health Informatics, University of Waterloo (Canada)",
         link: 'https://uwaterloo.ca/advanced-interface-design-lab/people-profiles/plinio-pelegrini-morita'
       },
       {
-        name: "Julie Parsonnet",
-        description: "Professor of Medicine and of Epidemiology and Population Health at Stanford University.",
+        name: "Julie Parsonnet, MD",
+        description: "Professor of Medicine and of Epidemiology and Population Health, Stanford University",
         link: 'https://profiles.stanford.edu/julie-parsonnet'
       },
       {
-        name: "Charles Belle",
-        description: "Fellow at Center for Internet and Society at Stanford Law School.",
-        link: 'http://cyberlaw.stanford.edu/about/people/charles-belle'
-      }
+        name: "Harper Reed",
+        description: "Senior Fellow, USC Annenberg Innovation Lab",
+        link: 'https://harperreed.com/'
+      },
+      {
+        name: "Harper Reed",
+        description: "Senior Fellow, USC Annenberg Innovation Lab",
+        link: 'https://harperreed.com/'
+      },
+      {
+        name: "Asa Tapley, MD, MSc",
+        description: "Fellow, Allergy and Infectious Diseases, University of Washington",
+        link: 'https://aid.uw.edu/fellow/asa-tapley'
+      },
     ],
     founders: [
       {

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -374,18 +374,13 @@ export default {
       },
       {
         name: "Plinio Pelegrini Morita, PhD",
-        description: "Assistant Professor and J.W. Graham Information Technology Emerging Leader Chair in Applied Health Informatics, University of Waterloo (Canada)",
+        description: "J.W. Graham Information Technology Emerging Leader Chair in Applied Health Informatics, University of Waterloo",
         link: 'https://uwaterloo.ca/advanced-interface-design-lab/people-profiles/plinio-pelegrini-morita'
       },
       {
         name: "Julie Parsonnet, MD",
         description: "Professor of Medicine and of Epidemiology and Population Health, Stanford University",
         link: 'https://profiles.stanford.edu/julie-parsonnet'
-      },
-      {
-        name: "Harper Reed",
-        description: "Senior Fellow, USC Annenberg Innovation Lab",
-        link: 'https://harperreed.com/'
       },
       {
         name: "Harper Reed",


### PR DESCRIPTION
- Added a few additional advisers
- Alphabetized list by last name
- Made the PhD listings consistent
- Shortened one bio (Plinio Morita) b/c its length was much longer than others and visually awkward

Preview below:

![Screen Shot 2020-05-13 at 7 42 53 PM](https://user-images.githubusercontent.com/16062590/81876973-f1cf3680-9551-11ea-8ba8-cb8ecc0853d9.png)
