### PR TITLE
Add media@ to news and join pages

### DIFF
--- a/pages/join.vue
+++ b/pages/join.vue
@@ -129,7 +129,9 @@
               </li>
               <li>
                 General:
-                <a href="mailto: contact@covid-watch.org">contact@covid-watch.org</a>
+                <a href="mailto: contact@covid-watch.org"
+                  >contact@covid-watch.org</a
+                >
               </li>
             </ul>
           </v-col>

--- a/pages/join.vue
+++ b/pages/join.vue
@@ -75,10 +75,21 @@
 
 
         <v-row class="mb-12">
-            <v-col>
-                <h3>Other Inquiries?</h3>
-                <p class="mt-8"><a class="primary--text" style="font-weight:600;text-decoration:none;" href="mailto: contact@covid-watch.org">Contact us</a> for more information.</p>
-            </v-col>
+          <v-col>
+            <h3>Other Inquiries?</h3>
+            <p class="mt-8">Reach out to our team:</p>
+
+            <ul>
+              <li>
+                Media:
+                <a href="mailto:media@covid-watch.org">media@covid-watch.org</a>
+              </li>
+              <li>
+                General:
+                <a href="mailto: contact@covid-watch.org">contact@covid-watch.org</a>
+              </li>
+            </ul>
+          </v-col>
         </v-row>
 
       </v-col>

--- a/pages/news.vue
+++ b/pages/news.vue
@@ -2,35 +2,31 @@
   <v-container>
     <v-row id="news" :class="pageSectionClass">
       <v-col>
-        <v-row id="hero" >
+        <v-row id="hero">
           <v-col :md="7" :sm="12" cols="12">
-            <h1>News and Media</h1>
-            <div
-              id="filters"
-              class="mt-10" 
-              style="max-width:500px;"
-            >
+            <h1 class="mb-5">News and Media</h1>
+            <p>
+              Want to reach our press team? Contact us at
+              <a
+                href="mailto:media@covid-watch.org"
+              >media@covid-watch.org</a>.
+            </p>
+            <div id="filters" class="mt-10" style="max-width:500px;">
               <v-col :sm="8" :md="1">
                 <p class="title mb-0">Filter:</p>
               </v-col>
-              
+
               <v-row id="filter-container">
                 <v-col :sm="8" :md="1">
-                  <Button secondary @click="toShow = 'all'" class="filter">
-                    All News
-                  </Button>
+                  <Button secondary @click="toShow = 'all'" class="filter">All News</Button>
                 </v-col>
 
                 <v-col :sm="8" :md="1">
-                  <Button secondary @click="toShow = 'mentions'" class="filter">
-                    Mentions
-                  </Button>
+                  <Button secondary @click="toShow = 'mentions'" class="filter">Mentions</Button>
                 </v-col>
 
                 <v-col :sm="8" :md="1">
-                  <Button secondary @click="toShow = 'releases'" class="filter">
-                    Press Releases
-                  </Button>
+                  <Button secondary @click="toShow = 'releases'" class="filter">Press Releases</Button>
                 </v-col>
               </v-row>
             </div>
@@ -83,7 +79,6 @@
       max-width: 260px;
     }
   }
-
 }
 </style>
 

--- a/pages/news.vue
+++ b/pages/news.vue
@@ -7,26 +7,30 @@
             <h1 class="mb-5">News and Media</h1>
             <p>
               Want to reach our press team? Contact us at
-              <a
-                href="mailto:media@covid-watch.org"
-              >media@covid-watch.org</a>.
+              <a href="mailto:media@covid-watch.org">media@covid-watch.org</a>.
             </p>
-            <div id="filters" class="mt-10" style="max-width:500px;">
+            <div id="filters" class="mt-10" style="max-width: 500px;">
               <v-col :sm="8" :md="1">
                 <p class="title mb-0">Filter:</p>
               </v-col>
 
               <v-row id="filter-container">
                 <v-col :sm="8" :md="1">
-                  <Button secondary @click="toShow = 'all'" class="filter">All News</Button>
+                  <Button secondary @click="toShow = 'all'" class="filter"
+                    >All News</Button
+                  >
                 </v-col>
 
                 <v-col :sm="8" :md="1">
-                  <Button secondary @click="toShow = 'mentions'" class="filter">Mentions</Button>
+                  <Button secondary @click="toShow = 'mentions'" class="filter"
+                    >Mentions</Button
+                  >
                 </v-col>
 
                 <v-col :sm="8" :md="1">
-                  <Button secondary @click="toShow = 'releases'" class="filter">Press Releases</Button>
+                  <Button secondary @click="toShow = 'releases'" class="filter"
+                    >Press Releases</Button
+                  >
                 </v-col>
               </v-row>
             </div>


### PR DESCRIPTION
## Summary

Add media@covid-watch.org to /news and /join.

## Screenshots
On /news:
![image](https://user-images.githubusercontent.com/7595169/82077337-1cc1a380-9694-11ea-9bff-352d91329e09.png)

On /join:
![image](https://user-images.githubusercontent.com/7595169/82077744-cd2fa780-9694-11ea-9743-015126d1a665.png)
