### PR TITLE
add new volunteering typeform to /join

### DIFF
--- a/pages/join.vue
+++ b/pages/join.vue
@@ -24,7 +24,6 @@
             </div>
           </v-col>
 
-
           <v-spacer></v-spacer>
 
           <v-col :md="4" :sm="8">
@@ -44,11 +43,10 @@
               If you'd like an invitation to the 500+ person Slack group that
               we're using to coordinate, fill out the form linked below.
             </p>
-            
 
             <v-col :md="4">
               <Button href="https://covidapp.typeform.com/to/MnRmBN">
-                  I want to volunteer!
+                I want to volunteer!
               </Button>
             </v-col>
 

--- a/pages/join.vue
+++ b/pages/join.vue
@@ -24,6 +24,7 @@
             </div>
           </v-col>
 
+
           <v-spacer></v-spacer>
 
           <v-col :md="4" :sm="8">
@@ -40,10 +41,16 @@
           <v-col>
             <h2>Volunteer</h2>
             <p class="mt-6">
-              If you'd like an invitation to the 400+ person Slack group that
-              we're using to coordinate, just send a message to
-              contact@covid-watch.org.
+              If you'd like an invitation to the 500+ person Slack group that
+              we're using to coordinate, fill out the form linked below.
             </p>
+            
+
+            <v-col :md="4">
+              <Button href="https://covidapp.typeform.com/to/MnRmBN">
+                  I want to volunteer!
+              </Button>
+            </v-col>
 
             <h4 class="mt-6 mb-4">Most Wanted Volunteers</h4>
             <ul>
@@ -166,10 +173,12 @@
 
 <script>
 import Newsletter from "../components/Newsletter";
+import Button from "../components/Button";
 
 export default {
   components: {
     Newsletter,
+    Button,
   },
   data: () => ({
     urgentRoles: [


### PR DESCRIPTION
Created a Typeform form for volunteers to fill out instead of emailing contact@covid-watch.org.  The spacing to the right of the button leaves a bit to be desired but want to ship this quick without refactoring the whole page orientation.  I played w justifying the button it in the middle and it looked really, really awkward.

![Screen Shot 2020-05-19 at 6 48 46 PM](https://user-images.githubusercontent.com/16062590/82386177-c93bb680-9a01-11ea-8000-c0aa014644b3.png)
