### PR TITLE
first pass add team members page

### DIFF
--- a/.github/workflows/airtable.yaml
+++ b/.github/workflows/airtable.yaml
@@ -3,8 +3,8 @@
 name: Airtable
 
 on:
-  schedule: 
-    - cron: '0 */12 * * *'
+  schedule:
+    - cron: "0 */12 * * *"
 
 jobs:
   build:
@@ -13,19 +13,29 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Run airtable script
+      - name: Run airtable script to fetch news
         env:
-          AIRTABLE_BASE_KEY: ${{ secrets.AIRTABLE_BASE_KEY }}
-          AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }} 
+          AIRTABLE_NEWS_BASE_KEY: ${{ secrets.AIRTABLE_NEWS_BASE_KEY }}
+          AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }}
         working-directory: scripts
         run: |
           pip3 install airtable-python-wrapper
-          chmod +x airtable-auto.py
-          ./airtable-auto.py
-          
+          chmod +x airtable-news-auto.py
+          ./airtable-news-auto.py
+
+      - name: Run airtable script to fetch team members
+        env:
+          AIRTABLE_NEWS_BASE_KEY: ${{ secrets.AIRTABLE_TEAM_BASE_KEY }}
+          AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }}
+        working-directory: scripts
+        run: |
+          pip3 install airtable-python-wrapper
+          chmod +x airtable-team-auto.py
+          ./airtable-team-auto.py
+
       - name: Create Pull Request
         uses: colbymorrison/create-pull-request@v2
         with:
-          commit-message: "auto-add new news"
-          title: "Airtable GitHub action -- Update News"
-          body: "New News from Airtable"
+          commit-message: "auto-add from Airtable"
+          title: "Airtable GitHub action -- Update News and Team"
+          body: "Updates to News and Team Members from Airtable"

--- a/assets/data/teamlist.json
+++ b/assets/data/teamlist.json
@@ -1,0 +1,61 @@
+{
+  "Administrative": [
+    "Chuck Raby",
+    "Claire Liu",
+    "Denis Memiko",
+    "Eve Dill",
+    "Indrajit Shaw",
+    "Jeff Schwaber",
+    "Jessica Gross",
+    "Jolene Elizabeth",
+    "Kevin Philips",
+    "Oliver Nash",
+    "Rebecca Yu"
+  ],
+  "Communications": [
+    "Cherry Wu",
+    "Grant Slater",
+    "Mariati Messinger",
+    "Travis Marsh",
+    "Zack Astran"
+  ],
+  "Culture": [
+    "Erin LeBeau",
+    "Laure Merlin",
+    "Lawrence Kang",
+    "Louis Kang",
+    "Sydney Von Arx"
+  ],
+  "Engineering": [
+    "Dave Hunt",
+    "Henry de Valence",
+    "Ian Brown",
+    "Isaiah Becker-Mayer",
+    "Jesse Colligan",
+    "Joshua Liebow-Feeser",
+    "Kaushik Basnet",
+    "Kim de Rosa",
+    "Madhava Jay",
+    "Mark Ingle",
+    "Michael Shen",
+    "Nikhil Kumar",
+    "Nitin Kumar",
+    "Pavlo Apisov",
+    "Prabhu Inbarajan ",
+    "Rachel Quartararo",
+    "Scott Leibrand",
+    "Taylor Quartararo",
+    "Wenfei Zhou"
+  ],
+  "Product": [
+    "Jo Zeng",
+    "Michelle Xie",
+    "Rich Dandliker",
+    "Sameer Halai",
+    "Sebastien Le Tuan",
+    "Tessa Alexanian",
+    "Thi Nguyen",
+    "Victoria Nguyen",
+    "Victoria Skelly"
+  ]
+}

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -323,75 +323,11 @@
 <script>
 import Button from "../components/Button.vue";
 import CTA from "../components/CTA.vue";
+import json from "../assets/data/teamlist.json";
 
 export default {
   data: () => ({
-    teamMembers: {
-      administrative: [
-        "Aaron Theolet",
-        "Chuck Raby",
-        "Claire Liu",
-        "Denis Memiko",
-        "Eve Dill",
-        "Indrajit Shaw",
-        "Jeff Schwaber",
-        "Jessica Gross",
-        "Jolene Elizabeth",
-        "Kevin Philips",
-        "Oliver Nash",
-        "Rebecca Yu",
-      ],
-      communications: [
-        "Andreas Ink",
-        "Cherry Wu",
-        "Grant Slater",
-        "Mariati Messinger",
-        "Travis Marsh",
-        "Zack Astran",
-      ],
-      product: [
-        "Helen He",
-        "Jo Zeng",
-        "Michelle Xie",
-        "Rich Dandliker",
-        "Sameer Halai",
-        "Sebastien Le Tuan",
-        "Tessa Alexanian",
-        "Thi Nguyen",
-        "Victoria Nguyen",
-        "Victoria Skelly",
-      ],
-      engineering: [
-        "Colby Morrison",
-        "Dave Hunt",
-        "Henry de Valence",
-        "Ian Brown",
-        "Isaiah Becker-Mayer",
-        "Jesse Colligan",
-        "Joshua Liebow-Feeser",
-        "Kaushik Basnet",
-        "Kim de Rosa",
-        "Madhava Jay",
-        "Mark Ingle",
-        "Michael Shen",
-        "Nikhil Kumar",
-        "Nitin Kumar",
-        "Pavlo Apisov",
-        "Prabhu Inbarajan ",
-        "Racherl Quartararo",
-        "Scott Leibrand",
-        "Taylor Quartararo",
-        "Wenfei Zhou",
-      ],
-      culture: [
-        "Angie Kim",
-        "Erin LeBeau",
-        "Laure Merlin",
-        "Lawrence Kang",
-        "Louis Kang",
-        "Sydney Von Arx",
-      ],
-    },
+    teamMembers: json,
     callsToAction: [
       {
         button_text: "Volunteer",

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -232,6 +232,79 @@
           </v-col>
         </v-row>
       </v-row>
+
+      <v-row :class="pageSectionClass" id="team-members">
+        <v-col class="mb-10" :md="4" :sm="8">
+          <h3 class="pt-5">Team Members</h3>
+        </v-col>
+
+
+        <template>
+          <v-container class="grey lighten-5">
+            <h4 class="mb-1">Communications</h4>
+            <v-row no-gutters>
+              <v-col v-for="(member, n) in teamMembers.communications" :key="n" cols="12" sm="3">
+                <div>
+                  <div>{{ member }}</div>
+                </div>
+              </v-col>
+            </v-row>
+          </v-container>
+        </template>
+
+        <template>
+          <v-container class="grey lighten-5">
+            <h4 class="mb-1">Administrative</h4>
+
+            <v-row no-gutters>
+              <v-col v-for="(member, n) in teamMembers.administrative" :key="n" cols="12" sm="3">
+                <div>
+                  <div >{{ member }}</div>
+                </div>
+              </v-col>
+            </v-row>
+          </v-container>
+        </template>
+
+        <template>
+          <v-container class="grey lighten-5">
+            <h4 class="mb-1">Product and Design</h4>
+            <v-row no-gutters>
+              <v-col v-for="(member, n) in teamMembers.product" :key="n" cols="12" sm="3">
+                <div>
+                  <div>{{ member }}</div>
+                </div>
+              </v-col>
+            </v-row>
+          </v-container>
+        </template>
+
+        <template>
+          <v-container class="grey lighten-5">
+            <h4 class="mb-1">Engineering</h4>
+            <v-row no-gutters>
+              <v-col v-for="(member, n) in teamMembers.engineering" :key="n" cols="12" sm="3">
+                <div>
+                  <div>{{ member }}</div>
+                </div>
+              </v-col>
+            </v-row>
+          </v-container>
+        </template>
+
+        <template>
+          <v-container class="grey lighten-5">
+            <h4 class="mb-1">People and Culture</h4>
+            <v-row no-gutters>
+              <v-col v-for="(member, n) in teamMembers.culture" :key="n" cols="12" sm="3">
+                <div>
+                  <div>{{ member }}</div>
+                </div>
+              </v-col>
+            </v-row>
+          </v-container>
+        </template>
+      </v-row>
     </v-row>
   </v-container>
 </template>
@@ -307,6 +380,62 @@ import CTA from "../components/CTA.vue";
 
 export default {
   data: () => ({
+    teamMembers: {
+      administrative: [
+        'Aaron Theolet',
+        'Chuck Raby',
+        'Claire Liu',
+        'Denis Memiko',
+        'Eve Dill',
+        'Indrajit Shaw',
+        'Jeff Schwaber',
+        'Jessica Gross',
+        'Jolene Elizabeth',
+        'Kevin Philips',
+        'Oliver Nash',
+        'Rebecca Yu'
+      ],
+      communications: [
+        'Andreas Ink',
+        'Cherry Wu',
+        'Grant Slater',
+        'Mariati Messinger',
+        'Travis Marsh',
+        'Zack Astran'
+      ],
+      product: [
+        'Helen He',
+        'Jo Zeng',
+        'Michelle Xie',
+        'Rich Dandliker',
+        'Sameer Halai',
+        'Sebastien Le Tuan',
+        'Tessa Alexanian',
+        'Thi Nguyen',
+        'Victoria Nguyen',
+        'Victoria Skelly'
+      ],
+      engineering: [
+        'Colby Morrison',       'Dave Hunt',
+        'Henry de Valence',     'Ian Brown',
+        'Isaiah Becker-Mayer',  'Jesse Colligan',
+        'Joshua Liebow-Feeser', 'Kaushik Basnet',
+        'Kim de Rosa',          'Madhava Jay',
+        'Mark Ingle',           'Michael Shen',
+        'Nikhil Kumar',         'Nitin Kumar',
+        'Pavlo Apisov',         'Prabhu Inbarajan ',
+        'Racherl Quartararo',   'Scott Leibrand',
+        'Taylor Quartararo',    'Wenfei Zhou'
+      ],
+      culture: [
+        'Angie Kim',
+        'Erin LeBeau',
+        'Laure Merlin',
+        'Lawrence Kang',
+        'Louis Kang',
+        'Sydney Von Arx'
+      ],
+    },
     callsToAction: [
       {
         button_text: "Volunteer",

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -223,7 +223,7 @@
             v-for="(collab, i) in collaborator_projects"
             :key="i"
             :id="collab.id"
-            class="text-center collab-img-col mb-6"
+            class="text-center collab-img-col"
           >
             <a target="_blank" :href="collab.url">
               <v-img class="collab-img" :src="collab.src" contain />

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -238,89 +238,11 @@
           <h3 class="pt-5">Team Members</h3>
         </v-col>
 
-        <template>
-          <v-container class="grey lighten-5">
-            <h4 class="mb-1">Communications</h4>
+        <template v-for="(group, key) in teamMembers">
+          <v-container :key="key" class="grey lighten-5">
+            <h4 class="mb-1 text-capitalize">{{ key }}</h4>
             <v-row no-gutters>
-              <v-col
-                v-for="(member, n) in teamMembers.communications"
-                :key="n"
-                cols="12"
-                sm="3"
-              >
-                <div>
-                  <div>{{ member }}</div>
-                </div>
-              </v-col>
-            </v-row>
-          </v-container>
-        </template>
-
-        <template>
-          <v-container class="grey lighten-5">
-            <h4 class="mb-1">Administrative</h4>
-
-            <v-row no-gutters>
-              <v-col
-                v-for="(member, n) in teamMembers.administrative"
-                :key="n"
-                cols="12"
-                sm="3"
-              >
-                <div>
-                  <div>{{ member }}</div>
-                </div>
-              </v-col>
-            </v-row>
-          </v-container>
-        </template>
-
-        <template>
-          <v-container class="grey lighten-5">
-            <h4 class="mb-1">Product and Design</h4>
-            <v-row no-gutters>
-              <v-col
-                v-for="(member, n) in teamMembers.product"
-                :key="n"
-                cols="12"
-                sm="3"
-              >
-                <div>
-                  <div>{{ member }}</div>
-                </div>
-              </v-col>
-            </v-row>
-          </v-container>
-        </template>
-
-        <template>
-          <v-container class="grey lighten-5">
-            <h4 class="mb-1">Engineering</h4>
-            <v-row no-gutters>
-              <v-col
-                v-for="(member, n) in teamMembers.engineering"
-                :key="n"
-                cols="12"
-                sm="3"
-              >
-                <div>
-                  <div>{{ member }}</div>
-                </div>
-              </v-col>
-            </v-row>
-          </v-container>
-        </template>
-
-        <template>
-          <v-container class="grey lighten-5">
-            <h4 class="mb-1">People and Culture</h4>
-            <v-row no-gutters>
-              <v-col
-                v-for="(member, n) in teamMembers.culture"
-                :key="n"
-                cols="12"
-                sm="3"
-              >
+              <v-col v-for="(member, n) in group" :key="n" cols="12" sm="3">
                 <div>
                   <div>{{ member }}</div>
                 </div>

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -153,22 +153,19 @@
       <v-row :class="pageSectionClass">
         <v-col cols="11">
           <div class="mb-5">
-            <h2>Advisers</h2>
+            <h3>Advisers</h3>
           </div>
         </v-col>
 
         <template>
-          <v-container class="grey lighten-5">
+          <v-container>
             <v-row no-gutters>
               <v-col v-for="(adviser, n) in advisers" :key="n" cols="12" sm="4">
                 <div class="adviser-card">
                   <a :href="adviser.link" target="_blank">
                     <div class="title-link title">{{ adviser.name }}</div>
                   </a>
-                  <img
-                    class="founder_img"
-                    src="../assets/about_us/top-accent.svg"
-                  />
+                  <img class="founder_img" src="../assets/about_us/top-accent.svg" />
                   <div>{{ adviser.description }}</div>
                 </div>
               </v-col>
@@ -179,7 +176,7 @@
 
       <!-- academic partners row-->
       <v-row :class="pageSectionClass" id="academic-partners">
-        <v-col class="mb-10" :md="4" :sm="8">
+        <v-col class="mb-10" cols="12">
           <h3 class="pt-5">Academic Partners</h3>
         </v-col>
 
@@ -212,7 +209,7 @@
 
       <!-- colabs row-->
       <v-row :class="pageSectionClass" id="collaborator-projects">
-        <v-col class="mb-10" :md="4" :sm="8">
+        <v-col class="mb-10" cols="12">
           <h3 class="pt-6">Collaborator Partners</h3>
         </v-col>
 
@@ -233,19 +230,19 @@
         </v-row>
       </v-row>
 
+      <!-- team members row -->
       <v-row :class="pageSectionClass" id="team-members">
-        <v-col class="mb-10" :md="4" :sm="8">
+        <v-col class="mb-10" cols="12">
           <h3 class="pt-5">Team Members</h3>
         </v-col>
 
         <template v-for="(group, key) in teamMembers">
-          <v-container :key="key" class="grey lighten-5">
-            <h4 class="mb-1 text-capitalize">{{ key }}</h4>
+          <v-container :key="key" class="mx-3">
+            <h4 class="mb-1 text-capitalize title">{{ key }}</h4>
+            <img class="founder_img" src="../assets/about_us/top-accent.svg" />
             <v-row no-gutters>
               <v-col v-for="(member, n) in group" :key="n" cols="12" sm="3">
-                <div>
-                  <div>{{ member }}</div>
-                </div>
+                <div>{{ member }}</div>
               </v-col>
             </v-row>
           </v-container>

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -238,12 +238,16 @@
           <h3 class="pt-5">Team Members</h3>
         </v-col>
 
-
         <template>
           <v-container class="grey lighten-5">
             <h4 class="mb-1">Communications</h4>
             <v-row no-gutters>
-              <v-col v-for="(member, n) in teamMembers.communications" :key="n" cols="12" sm="3">
+              <v-col
+                v-for="(member, n) in teamMembers.communications"
+                :key="n"
+                cols="12"
+                sm="3"
+              >
                 <div>
                   <div>{{ member }}</div>
                 </div>
@@ -257,9 +261,14 @@
             <h4 class="mb-1">Administrative</h4>
 
             <v-row no-gutters>
-              <v-col v-for="(member, n) in teamMembers.administrative" :key="n" cols="12" sm="3">
+              <v-col
+                v-for="(member, n) in teamMembers.administrative"
+                :key="n"
+                cols="12"
+                sm="3"
+              >
                 <div>
-                  <div >{{ member }}</div>
+                  <div>{{ member }}</div>
                 </div>
               </v-col>
             </v-row>
@@ -270,7 +279,12 @@
           <v-container class="grey lighten-5">
             <h4 class="mb-1">Product and Design</h4>
             <v-row no-gutters>
-              <v-col v-for="(member, n) in teamMembers.product" :key="n" cols="12" sm="3">
+              <v-col
+                v-for="(member, n) in teamMembers.product"
+                :key="n"
+                cols="12"
+                sm="3"
+              >
                 <div>
                   <div>{{ member }}</div>
                 </div>
@@ -283,7 +297,12 @@
           <v-container class="grey lighten-5">
             <h4 class="mb-1">Engineering</h4>
             <v-row no-gutters>
-              <v-col v-for="(member, n) in teamMembers.engineering" :key="n" cols="12" sm="3">
+              <v-col
+                v-for="(member, n) in teamMembers.engineering"
+                :key="n"
+                cols="12"
+                sm="3"
+              >
                 <div>
                   <div>{{ member }}</div>
                 </div>
@@ -296,7 +315,12 @@
           <v-container class="grey lighten-5">
             <h4 class="mb-1">People and Culture</h4>
             <v-row no-gutters>
-              <v-col v-for="(member, n) in teamMembers.culture" :key="n" cols="12" sm="3">
+              <v-col
+                v-for="(member, n) in teamMembers.culture"
+                :key="n"
+                cols="12"
+                sm="3"
+              >
                 <div>
                   <div>{{ member }}</div>
                 </div>
@@ -382,58 +406,68 @@ export default {
   data: () => ({
     teamMembers: {
       administrative: [
-        'Aaron Theolet',
-        'Chuck Raby',
-        'Claire Liu',
-        'Denis Memiko',
-        'Eve Dill',
-        'Indrajit Shaw',
-        'Jeff Schwaber',
-        'Jessica Gross',
-        'Jolene Elizabeth',
-        'Kevin Philips',
-        'Oliver Nash',
-        'Rebecca Yu'
+        "Aaron Theolet",
+        "Chuck Raby",
+        "Claire Liu",
+        "Denis Memiko",
+        "Eve Dill",
+        "Indrajit Shaw",
+        "Jeff Schwaber",
+        "Jessica Gross",
+        "Jolene Elizabeth",
+        "Kevin Philips",
+        "Oliver Nash",
+        "Rebecca Yu",
       ],
       communications: [
-        'Andreas Ink',
-        'Cherry Wu',
-        'Grant Slater',
-        'Mariati Messinger',
-        'Travis Marsh',
-        'Zack Astran'
+        "Andreas Ink",
+        "Cherry Wu",
+        "Grant Slater",
+        "Mariati Messinger",
+        "Travis Marsh",
+        "Zack Astran",
       ],
       product: [
-        'Helen He',
-        'Jo Zeng',
-        'Michelle Xie',
-        'Rich Dandliker',
-        'Sameer Halai',
-        'Sebastien Le Tuan',
-        'Tessa Alexanian',
-        'Thi Nguyen',
-        'Victoria Nguyen',
-        'Victoria Skelly'
+        "Helen He",
+        "Jo Zeng",
+        "Michelle Xie",
+        "Rich Dandliker",
+        "Sameer Halai",
+        "Sebastien Le Tuan",
+        "Tessa Alexanian",
+        "Thi Nguyen",
+        "Victoria Nguyen",
+        "Victoria Skelly",
       ],
       engineering: [
-        'Colby Morrison',       'Dave Hunt',
-        'Henry de Valence',     'Ian Brown',
-        'Isaiah Becker-Mayer',  'Jesse Colligan',
-        'Joshua Liebow-Feeser', 'Kaushik Basnet',
-        'Kim de Rosa',          'Madhava Jay',
-        'Mark Ingle',           'Michael Shen',
-        'Nikhil Kumar',         'Nitin Kumar',
-        'Pavlo Apisov',         'Prabhu Inbarajan ',
-        'Racherl Quartararo',   'Scott Leibrand',
-        'Taylor Quartararo',    'Wenfei Zhou'
+        "Colby Morrison",
+        "Dave Hunt",
+        "Henry de Valence",
+        "Ian Brown",
+        "Isaiah Becker-Mayer",
+        "Jesse Colligan",
+        "Joshua Liebow-Feeser",
+        "Kaushik Basnet",
+        "Kim de Rosa",
+        "Madhava Jay",
+        "Mark Ingle",
+        "Michael Shen",
+        "Nikhil Kumar",
+        "Nitin Kumar",
+        "Pavlo Apisov",
+        "Prabhu Inbarajan ",
+        "Racherl Quartararo",
+        "Scott Leibrand",
+        "Taylor Quartararo",
+        "Wenfei Zhou",
       ],
       culture: [
-        'Angie Kim',
-        'Erin LeBeau',
-        'Laure Merlin',
-        'Lawrence Kang',
-        'Louis Kang',
-        'Sydney Von Arx'
+        "Angie Kim",
+        "Erin LeBeau",
+        "Laure Merlin",
+        "Lawrence Kang",
+        "Louis Kang",
+        "Sydney Von Arx",
       ],
     },
     callsToAction: [

--- a/scripts/airtable-news-auto.py
+++ b/scripts/airtable-news-auto.py
@@ -1,0 +1,45 @@
+#! /usr/bin/env python3
+
+from airtable import Airtable
+import json
+import os
+
+VIEW_NAME = "^^dont_change_news_name"
+OUTPUT_PATH = "../assets/data/medialist.json"
+
+def valid_entry(entry):
+
+    for value in ["type", "url", "outlet_name", "title", "date"]:
+        if value not in entry:
+            return False
+
+    return True
+
+
+def main():
+    try:
+        # these keys have been set up Github /websites repo secrets already
+        airtable = Airtable(
+            os.environ["AIRTABLE_NEWS_BASE_KEY"],
+            "news",
+            api_key=os.environ["AIRTABLE_API_KEY"],
+        )
+    except KeyError:
+        print("Couldn't find airtable base key or api key")
+        exit(1)
+
+    media_list = []
+
+    for page in airtable.get_iter(view=VIEW_NAME):
+        for record in page:
+            new_values = record["fields"]
+
+            if valid_entry(new_values):
+                media_list.append(new_values)
+
+    with open(OUTPUT_PATH, "w") as f:
+        json.dump(media_list, f, indent=2, sort_keys=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/airtable-news-auto.py
+++ b/scripts/airtable-news-auto.py
@@ -5,6 +5,7 @@ import json
 import os
 
 VIEW_NAME = "^^dont_change_news_name"
+TABLE_NAME = "news"
 OUTPUT_PATH = "../assets/data/medialist.json"
 
 def valid_entry(entry):
@@ -21,7 +22,7 @@ def main():
         # these keys have been set up Github /websites repo secrets already
         airtable = Airtable(
             os.environ["AIRTABLE_NEWS_BASE_KEY"],
-            "news",
+            TABLE_NAME,
             api_key=os.environ["AIRTABLE_API_KEY"],
         )
     except KeyError:

--- a/scripts/airtable-team-auto.py
+++ b/scripts/airtable-team-auto.py
@@ -35,11 +35,14 @@ def main():
         for record in page:
             new_values = record["fields"]
 
+
+            print(new_values)
+            # print(new_values.get("team"))
             if valid_entry(new_values):
-                if team_list.get(new_values.team) is not None:
-                    team_list[new_values.team].append(new_values.name)
+                if team_list.get(new_values.get("team")) is not None:
+                    team_list[new_values.get("team")].append(new_values.get("name"))
                 else:
-                    team_list[new_values.team] = []
+                    team_list[new_values.get("team")] = []
 
 
     with open(OUTPUT_PATH, "w") as f:

--- a/scripts/airtable-team-auto.py
+++ b/scripts/airtable-team-auto.py
@@ -21,7 +21,7 @@ def main():
         # these keys have been set up Github /websites repo secrets already
         airtable = Airtable(
             os.environ["AIRTABLE_TEAM_BASE_KEY"],
-            "news",
+            "team",
             api_key=os.environ["AIRTABLE_API_KEY"],
         )
     except KeyError:

--- a/scripts/airtable-team-auto.py
+++ b/scripts/airtable-team-auto.py
@@ -5,9 +5,11 @@ import json
 import os
 
 
-def valid_entry(entry):
+VIEW_NAME = "^^dont_change_team_name"
+OUTPUT_PATH = "../assets/data/teamlist.json"
 
-    for value in ["type", "url", "outlet_name", "title", "date"]:
+def valid_entry(entry):
+    for value in ["name", "team"]:
         if value not in entry:
             return False
 
@@ -18,7 +20,7 @@ def main():
     try:
         # these keys have been set up Github /websites repo secrets already
         airtable = Airtable(
-            os.environ["AIRTABLE_BASE_KEY"],
+            os.environ["AIRTABLE_TEAM_BASE_KEY"],
             "news",
             api_key=os.environ["AIRTABLE_API_KEY"],
         )
@@ -26,17 +28,21 @@ def main():
         print("Couldn't find airtable base key or api key")
         exit(1)
 
-    media_list = []
+    team_list = {}
 
-    for page in airtable.get_iter(view="^^dont_change_news_name"):
+    for page in airtable.get_iter(view=VIEW_NAME):
         for record in page:
             new_values = record["fields"]
 
             if valid_entry(new_values):
-                media_list.append(new_values)
+                if team_list.get(new_values.team) is not None:
+                    team_list[new_values.team].append(new_values.name)
+                else:
+                    team_list[new_values.team] = []
 
-    with open("../assets/data/medialist.json", "w") as f:
-        json.dump(media_list, f, indent=2, sort_keys=True)
+
+    with open(OUTPUT_PATH, "w") as f:
+        json.dump(team_list, f, indent=2, sort_keys=True)
 
 
 if __name__ == "__main__":

--- a/scripts/airtable-team-auto.py
+++ b/scripts/airtable-team-auto.py
@@ -6,6 +6,7 @@ import os
 
 
 VIEW_NAME = "^^dont_change_team_name"
+TABLE_NAME = "team"
 OUTPUT_PATH = "../assets/data/teamlist.json"
 
 def valid_entry(entry):
@@ -21,7 +22,7 @@ def main():
         # these keys have been set up Github /websites repo secrets already
         airtable = Airtable(
             os.environ["AIRTABLE_TEAM_BASE_KEY"],
-            "team",
+            TABLE_NAME,
             api_key=os.environ["AIRTABLE_API_KEY"],
         )
     except KeyError:


### PR DESCRIPTION
At bottom of /about page.  Feel free to adjust and play with spacing and general design.  Our three bottom sections on /about "Academic Partners", "Collaborator Partners", and "Team Members" are now all slightly different layout and organization and it looks visually very meh right now.

Perhaps just putting the Academic Partners logos under the header (like Collaborator Partners) may go a long way in making this more cohesive.

The team list is a good candidate for modularization as a component if anyone wants to devote time to that.  Low priority imo but definitely would be cleaner code! :)

Or if someone wants to Airtable-fy this, go ahead!  Goal was to ship this quickly so that in conversations happening this week organizations will look at our site and hopefully have more confidence in our team/stability.

![Screen Shot 2020-05-24 at 7 20 42 PM](https://user-images.githubusercontent.com/16062590/82767194-ac352800-9df3-11ea-858d-ddde0efc9d52.png)
