### PR TITLE
add text timeline to /about, tina request

### DIFF
--- a/pages/about.vue
+++ b/pages/about.vue
@@ -115,15 +115,31 @@
           <div class="mb-5">
             <h2>Team</h2>
           </div>
-            <p class="subtitle">
-              Covid Watch is a group of more than 500 volunteers from around the world, including experts in privacy and public health, technologists, developers, writers, and designers.
+          <p class="subtitle">
+            Covid Watch is a group of more than 500 volunteers from around the
+            world, including experts in privacy and public health,
+            technologists, developers, writers, and designers.
+          </p>
 
-            <p class="subtitle">
-              Our team of Stanford and Waterloo researchers was the first in the world to publish a <a href="/covid_watch_whitepaper.pdf">white paper</a>, <a href="https://testflight.apple.com/join/gtAh2Xeu">develop</a>, and <a href="https://github.com/covid19risk/">open source</a> decentralized Bluetooth exposure alert technology in early March 2020. Our <a href="https://github.com/TCNCoalition/TCN">TCN protocol</a> led to the rapid development of very similar anonymous protocols worldwide, like DP3T, PACT, and Google/Apple exposure notifications. 
-            </p>
-            <p class="subtitle">
-              Our nonprofit continues to advocate for digital privacy rights and anonymous, decentralized COVID-19 exposure alerts. Our mission is to build mobile technology to fight the pandemic while defending digital privacy.
-            </p>
+          <p class="subtitle">
+            Our team of Stanford and Waterloo researchers was the first in the
+            world to publish a
+            <a href="/covid_watch_whitepaper.pdf">white paper</a>,
+            <a href="https://testflight.apple.com/join/gtAh2Xeu">develop</a>,
+            and
+            <a href="https://github.com/covid19risk/">open source</a>
+            decentralized Bluetooth exposure alert technology in early March
+            2020. Our
+            <a href="https://github.com/TCNCoalition/TCN">TCN protocol</a> led
+            to the rapid development of very similar anonymous protocols
+            worldwide, like DP3T, PACT, and Google/Apple exposure notifications.
+          </p>
+          <p class="subtitle">
+            Our nonprofit continues to advocate for digital privacy rights and
+            anonymous, decentralized COVID-19 exposure alerts. Our mission is to
+            build mobile technology to fight the pandemic while defending
+            digital privacy.
+          </p>
         </v-col>
 
         <template v-for="(founder, n) in founders">
@@ -526,23 +542,22 @@ export default {
     CTA,
   },
   computed: {
-    teamList: function() {
-       var teamList = {};
+    teamList: function () {
+      var teamList = {};
 
-       this.airtableTeamList.forEach(elt => {
-            if(elt.team){
-                if(teamList[elt.team]){
-                    teamList[elt.team].push(elt.name)
-                }
-                else{
-                    teamList[elt.team] = [elt.name]
-                }
-            }
-       });
+      this.airtableTeamList.forEach((elt) => {
+        if (elt.team) {
+          if (teamList[elt.team]) {
+            teamList[elt.team].push(elt.name);
+          } else {
+            teamList[elt.team] = [elt.name];
+          }
+        }
+      });
 
-       return teamList;
-       }
+      return teamList;
     },
+  },
   head() {
     return {
       title: "About Us | Covid Watch",

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -115,11 +115,15 @@
           <div class="mb-5">
             <h2>Team</h2>
           </div>
-          <p class="subtitle">
-            Covid Watch is a group of more than 400 volunteers from around the
-            world. Our team includes experts in privacy and public health,
-            technologists, developers, writers and designers.
-          </p>
+            <p class="subtitle">
+              Covid Watch is a group of more than 500 volunteers from around the world, including experts in privacy and public health, technologists, developers, writers, and designers.
+
+            <p class="subtitle">
+              Our team of Stanford and Waterloo researchers was the first in the world to publish a <a href="/covid_watch_whitepaper.pdf">white paper</a>, <a href="https://testflight.apple.com/join/gtAh2Xeu">develop</a>, and <a href="https://github.com/covid19risk/">open source</a> decentralized Bluetooth exposure alert technology in early March 2020. Our <a href="https://github.com/TCNCoalition/TCN">TCN protocol</a> led to the rapid development of very similar anonymous protocols worldwide, like DP3T, PACT, and Google/Apple exposure notifications. 
+            </p>
+            <p class="subtitle">
+              Our nonprofit continues to advocate for digital privacy rights and anonymous, decentralized COVID-19 exposure alerts. Our mission is to build mobile technology to fight the pandemic while defending digital privacy.
+            </p>
         </v-col>
 
         <template v-for="(founder, n) in founders">


### PR DESCRIPTION
Add some additional text to /about page contextualizing Covid Watch's history.  Tina requested this of me via Slack.

<img width="1191" alt="Screen Shot 2020-05-29 at 7 44 19 AM" src="https://user-images.githubusercontent.com/16062590/83256298-35e04f00-a180-11ea-8379-441f8f079ead.png">
