### PR TITLE
/news: style filters to look like AppBar

### DIFF
--- a/assets/mixins.scss
+++ b/assets/mixins.scss
@@ -7,4 +7,5 @@
   right: 0;
   top: 0;
   border-bottom: $border-width solid $border-color;
+  display: inherit;
 }

--- a/components/AppBar.vue
+++ b/components/AppBar.vue
@@ -4,7 +4,13 @@
       <v-row align="center" justify="space-between">
         <v-col cols="8" sm="auto">
           <nuxt-link to="/">
-            <v-img :src="logoSvg" alt="Covid Watch" id="logo-desktop" max-width="265px" contain></v-img>
+            <v-img
+              :src="logoSvg"
+              alt="Covid Watch"
+              id="logo-desktop"
+              max-width="265px"
+              contain
+            ></v-img>
           </nuxt-link>
         </v-col>
         <v-spacer></v-spacer>
@@ -18,7 +24,8 @@
               :title="link.title"
               :to="link.href"
               nuxt
-            >{{ link.title }}</MenuButton>
+              >{{ link.title }}</MenuButton
+            >
           </v-toolbar-items>
         </v-col>
         <!--Mobile menu-->
@@ -32,7 +39,9 @@
               </template>
               <v-list class="d-md-none">
                 <v-list-item v-for="link in navLinks" :key="link.title">
-                  <nuxt-link class="link" :to="link.href">{{ link.title }}</nuxt-link>
+                  <nuxt-link class="link" :to="link.href">{{
+                    link.title
+                  }}</nuxt-link>
                 </v-list-item>
               </v-list>
             </v-menu>
@@ -70,14 +79,14 @@ import MenuButton from "./MenuButton.vue";
 export default {
   name: "AppBar",
   components: {
-    MenuButton
+    MenuButton,
   },
   props: {
     navLinks: Array,
-    title: String
+    title: String,
   },
   data: () => ({
-    logoSvg: require("../assets/logo/logo_text_blue.svg")
-  })
+    logoSvg: require("../assets/logo/logo_text_blue.svg"),
+  }),
 };
 </script>

--- a/components/AppBar.vue
+++ b/components/AppBar.vue
@@ -4,13 +4,7 @@
       <v-row align="center" justify="space-between">
         <v-col cols="8" sm="auto">
           <nuxt-link to="/">
-            <v-img
-              :src="logoSvg"
-              alt="Covid Watch"
-              id="logo-desktop"
-              max-width="265px"
-              contain
-            ></v-img>
+            <v-img :src="logoSvg" alt="Covid Watch" id="logo-desktop" max-width="265px" contain></v-img>
           </nuxt-link>
         </v-col>
         <v-spacer></v-spacer>
@@ -18,17 +12,13 @@
         <!--Desktop menu-->
         <v-col class="hidden-sm-and-down" sm="auto">
           <v-toolbar-items>
-            <v-btn
+            <MenuButton
               v-for="link in navLinks"
               :key="link.title"
               :title="link.title"
               :to="link.href"
               nuxt
-              text
-              :ripple="false"
-              class="py-4"
-              >{{ link.title }}</v-btn
-            >
+            >{{ link.title }}</MenuButton>
           </v-toolbar-items>
         </v-col>
         <!--Mobile menu-->
@@ -42,9 +32,7 @@
               </template>
               <v-list class="d-md-none">
                 <v-list-item v-for="link in navLinks" :key="link.title">
-                  <nuxt-link class="link" :to="link.href">
-                    {{ link.title }}
-                  </nuxt-link>
+                  <nuxt-link class="link" :to="link.href">{{ link.title }}</nuxt-link>
                 </v-list-item>
               </v-list>
             </v-menu>
@@ -57,63 +45,39 @@
 
 <style lang="scss" scoped>
 header.v-app-bar {
-  // Desktop menu links
-  .v-btn {
-    color: var(--v-primary-base);
-    font-weight: 600;
-    text-transform: none;
-    font-size: 20px;
-
+  // Mobile menu links
+  .v-list-item {
     &:before {
-      display: none;
+      @include pseudo-background;
+      border-radius: inherit;
+      color: inherit;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.2s cubic-bezier(0.4, 0, 0.6, 1);
+      background-color: currentColor;
     }
 
-    &:not(#mobile-menu-btn):hover:after {
-      @include pseudo-background(3px, rgb(67, 196, 217, 0.5));
-      width: calc(
-        100% - 32px
-      ); // by default, the buttons have 16px padding on either side
+    .nuxt-link-active {
+      font-weight: 600;
     }
-
-    &--active {
-      font-weight: 700;
-
-      &:after {
-        @include pseudo-background(3px, var(--v-primary-base));
-        width: calc(
-          100% - 32px
-        ); // by default, the buttons have 16px padding on either side
-      }
-    }
-  }
-}
-// Mobile menu links
-.v-list-item {
-  &:before {
-    @include pseudo-background;
-    border-radius: inherit;
-    color: inherit;
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.2s cubic-bezier(0.4, 0, 0.6, 1);
-    background-color: currentColor;
-  }
-
-  .nuxt-link-active {
-    font-weight: 600;
   }
 }
 </style>
 
 <script>
+import MenuButton from "./MenuButton.vue";
+
 export default {
   name: "AppBar",
+  components: {
+    MenuButton
+  },
   props: {
     navLinks: Array,
-    title: String,
+    title: String
   },
   data: () => ({
-    logoSvg: require("../assets/logo/logo_text_blue.svg"),
-  }),
+    logoSvg: require("../assets/logo/logo_text_blue.svg")
+  })
 };
 </script>

--- a/components/MenuButton.vue
+++ b/components/MenuButton.vue
@@ -3,42 +3,45 @@
     :nuxt="nuxt"
     :to="to"
     :href="href"
-    @click="$emit('click', $event)"
+    :value="value"
     text
+    :ripple="false"
     class="btn-flat-underlined py-4"
+    @click="$emit('click', $event)"
   >
     <slot></slot>
   </v-btn>
 </template>
             
 <style lang="scss" scoped>
-.btn-flat-underlined {
-  &.v-btn {
+.v-btn-toggle > .btn-flat-underlined.v-btn,
+.btn-flat-underlined.v-btn {
+  color: var(--v-primary-base);
+  font-weight: 600;
+  text-transform: none;
+  font-size: 20px;
+  border: none;
+
+  &:before {
+    display: none;
+  }
+
+  &:not(#mobile-menu-btn):hover:after {
+    @include pseudo-background(3px, rgb(67, 196, 217, 0.5));
+    width: calc(
+      100% - 32px
+    ); // by default, the buttons have 16px padding on either side
+  }
+
+  &--active {
     color: var(--v-primary-base);
-    font-weight: 600;
-    text-transform: none;
-    font-size: 20px;
+    font-weight: 700;
 
-    &:before {
-      display: none;
-    }
-
-    &:not(#mobile-menu-btn):hover:after {
-      @include pseudo-background(3px, rgb(67, 196, 217, 0.5));
+    &:after {
+      @include pseudo-background(3px, var(--v-primary-base));
       width: calc(
         100% - 32px
       ); // by default, the buttons have 16px padding on either side
-    }
-
-    &--active {
-      font-weight: 700;
-
-      &:after {
-        @include pseudo-background(3px, var(--v-primary-base));
-        width: calc(
-          100% - 32px
-        ); // by default, the buttons have 16px padding on either side
-      }
     }
   }
 }
@@ -50,7 +53,8 @@ export default {
   props: {
     href: String,
     to: String,
-    nuxt: Boolean
+    nuxt: Boolean,
+    value: [String, Number, Boolean]
   }
 };
 </script>

--- a/components/MenuButton.vue
+++ b/components/MenuButton.vue
@@ -12,7 +12,7 @@
     <slot></slot>
   </v-btn>
 </template>
-            
+
 <style lang="scss" scoped>
 .v-btn-toggle > .btn-flat-underlined.v-btn,
 .btn-flat-underlined.v-btn {
@@ -54,7 +54,7 @@ export default {
     href: String,
     to: String,
     nuxt: Boolean,
-    value: [String, Number, Boolean]
-  }
+    value: [String, Number, Boolean],
+  },
 };
 </script>

--- a/components/MenuButton.vue
+++ b/components/MenuButton.vue
@@ -1,0 +1,56 @@
+<template>
+  <v-btn
+    :nuxt="nuxt"
+    :to="to"
+    :href="href"
+    @click="$emit('click', $event)"
+    text
+    class="btn-flat-underlined py-4"
+  >
+    <slot></slot>
+  </v-btn>
+</template>
+            
+<style lang="scss" scoped>
+.btn-flat-underlined {
+  &.v-btn {
+    color: var(--v-primary-base);
+    font-weight: 600;
+    text-transform: none;
+    font-size: 20px;
+
+    &:before {
+      display: none;
+    }
+
+    &:not(#mobile-menu-btn):hover:after {
+      @include pseudo-background(3px, rgb(67, 196, 217, 0.5));
+      width: calc(
+        100% - 32px
+      ); // by default, the buttons have 16px padding on either side
+    }
+
+    &--active {
+      font-weight: 700;
+
+      &:after {
+        @include pseudo-background(3px, var(--v-primary-base));
+        width: calc(
+          100% - 32px
+        ); // by default, the buttons have 16px padding on either side
+      }
+    }
+  }
+}
+</style>
+
+<script>
+export default {
+  name: "MenuButton",
+  props: {
+    href: String,
+    to: String,
+    nuxt: Boolean
+  }
+};
+</script>

--- a/pages/news.vue
+++ b/pages/news.vue
@@ -7,31 +7,17 @@
             <h1 class="mb-5">News and Media</h1>
             <p>
               Want to reach our press team? Contact us at
-              <a href="mailto:media@covid-watch.org">media@covid-watch.org</a>.
+              <a
+                href="mailto:media@covid-watch.org"
+              >media@covid-watch.org</a>.
             </p>
-            <div id="filters" class="mt-10" style="max-width: 500px;">
-              <v-col :sm="8" :md="1">
-                <p class="title mb-0">Filter:</p>
-              </v-col>
-
-              <v-row id="filter-container">
-                <v-col :sm="8" :md="1">
-                  <Button secondary @click="toShow = 'all'" class="filter"
-                    >All News</Button
-                  >
-                </v-col>
-
-                <v-col :sm="8" :md="1">
-                  <Button secondary @click="toShow = 'mentions'" class="filter"
-                    >Mentions</Button
-                  >
-                </v-col>
-
-                <v-col :sm="8" :md="1">
-                  <Button secondary @click="toShow = 'releases'" class="filter"
-                    >Press Releases</Button
-                  >
-                </v-col>
+            <div class="mt-10" style="max-width: 500px;">
+              <v-row id="filter-container" justify="space-evenly">
+                <v-btn-toggle v-model="toShow" mandatory id="filter-group">
+                  <MenuButton value="all" class="filter">All News</MenuButton>
+                  <MenuButton value="mentions" class="filter">Mentions</MenuButton>
+                  <MenuButton value="releases" class="filter">Press Releases</MenuButton>
+                </v-btn-toggle>
               </v-row>
             </div>
           </v-col>
@@ -39,24 +25,14 @@
           <v-spacer></v-spacer>
 
           <v-col :sm="8" :md="4">
-            <img
-              id="bench-dude"
-              src="../assets/news_page/bench_dude.svg"
-              alt="news"
-            />
+            <img id="bench-dude" src="../assets/news_page/bench_dude.svg" alt="news" />
           </v-col>
         </v-row>
 
         <!-- all news cards section -->
         <v-row id="news-cards" class="mt-8">
           <!-- modularized NewsCard version -->
-          <v-col
-            :md="4"
-            :sm="6"
-            cols="12"
-            v-for="(card, i) in cardsToRender"
-            :key="i"
-          >
+          <v-col :md="4" :sm="6" cols="12" v-for="(card, i) in cardsToRender" :key="i">
             <NewsCard :card="card"></NewsCard>
           </v-col>
         </v-row>
@@ -72,9 +48,12 @@
 }
 
 #news {
-  #filters {
-    display: flex;
-    justify-content: space-evenly;
+  @import "~vuetify/src/styles/settings/_variables";
+
+  #filter-group {
+    @media #{map-get($display-breakpoints, 'sm-and-down')} {
+      flex-direction: column;
+    }
   }
 
   #bench-dude {
@@ -97,8 +76,9 @@
 </style>
 
 <script>
-import NewsCard from "../components/NewsCard.vue";
 import Button from "../components/Button.vue";
+import MenuButton from "../components/MenuButton.vue";
+import NewsCard from "../components/NewsCard.vue";
 import json from "../assets/data/medialist.json";
 import gsap from "gsap"; //this is a javascript animation library, more info: https://www.vuemastery.com/courses/animating-vue/intro-to-GSAP-3
 
@@ -110,21 +90,22 @@ export default {
       scale: 0.8,
       x: 0,
       ease: "power1",
-      stagger: 0.02,
+      stagger: 0.02
     });
   },
   components: {
-    NewsCard,
     Button,
+    MenuButton,
+    NewsCard
   },
-  updated: function () {
+  updated: function() {
     gsap.from(".news-card", {
       duration: 0.2,
       opacity: 0,
       scale: 0.8,
       x: 0,
       ease: "power1",
-      stagger: 0.02,
+      stagger: 0.02
     });
   },
   computed: {
@@ -132,24 +113,20 @@ export default {
       if (this.toShow === "all") {
         return this.airtableList;
       } else if (this.toShow === "mentions") {
-        return this.airtableList.filter(
-          (card) => card.type === "press_mention"
-        );
+        return this.airtableList.filter(card => card.type === "press_mention");
       } else {
-        return this.airtableList.filter(
-          (card) => card.type === "press_release"
-        );
+        return this.airtableList.filter(card => card.type === "press_release");
       }
-    },
+    }
   },
   data: () => ({
     airtableList: json.sort((a, b) => (a.date < b.date ? 1 : -1)),
-    toShow: "all",
+    toShow: "all"
   }),
   head() {
     return {
-      title: "News | Covid Watch",
+      title: "News | Covid Watch"
     };
-  },
+  }
 };
 </script>

--- a/pages/news.vue
+++ b/pages/news.vue
@@ -7,16 +7,18 @@
             <h1 class="mb-5">News and Media</h1>
             <p>
               Want to reach our press team? Contact us at
-              <a
-                href="mailto:media@covid-watch.org"
-              >media@covid-watch.org</a>.
+              <a href="mailto:media@covid-watch.org">media@covid-watch.org</a>.
             </p>
             <div class="mt-10" style="max-width: 500px;">
               <v-row id="filter-container" justify="space-evenly">
                 <v-btn-toggle v-model="toShow" mandatory id="filter-group">
                   <MenuButton value="all" class="filter">All News</MenuButton>
-                  <MenuButton value="mentions" class="filter">Mentions</MenuButton>
-                  <MenuButton value="releases" class="filter">Press Releases</MenuButton>
+                  <MenuButton value="mentions" class="filter"
+                    >Mentions</MenuButton
+                  >
+                  <MenuButton value="releases" class="filter"
+                    >Press Releases</MenuButton
+                  >
                 </v-btn-toggle>
               </v-row>
             </div>
@@ -25,14 +27,24 @@
           <v-spacer></v-spacer>
 
           <v-col :sm="8" :md="4">
-            <img id="bench-dude" src="../assets/news_page/bench_dude.svg" alt="news" />
+            <img
+              id="bench-dude"
+              src="../assets/news_page/bench_dude.svg"
+              alt="news"
+            />
           </v-col>
         </v-row>
 
         <!-- all news cards section -->
         <v-row id="news-cards" class="mt-8">
           <!-- modularized NewsCard version -->
-          <v-col :md="4" :sm="6" cols="12" v-for="(card, i) in cardsToRender" :key="i">
+          <v-col
+            :md="4"
+            :sm="6"
+            cols="12"
+            v-for="(card, i) in cardsToRender"
+            :key="i"
+          >
             <NewsCard :card="card"></NewsCard>
           </v-col>
         </v-row>
@@ -90,22 +102,22 @@ export default {
       scale: 0.8,
       x: 0,
       ease: "power1",
-      stagger: 0.02
+      stagger: 0.02,
     });
   },
   components: {
     Button,
     MenuButton,
-    NewsCard
+    NewsCard,
   },
-  updated: function() {
+  updated: function () {
     gsap.from(".news-card", {
       duration: 0.2,
       opacity: 0,
       scale: 0.8,
       x: 0,
       ease: "power1",
-      stagger: 0.02
+      stagger: 0.02,
     });
   },
   computed: {
@@ -113,20 +125,24 @@ export default {
       if (this.toShow === "all") {
         return this.airtableList;
       } else if (this.toShow === "mentions") {
-        return this.airtableList.filter(card => card.type === "press_mention");
+        return this.airtableList.filter(
+          (card) => card.type === "press_mention"
+        );
       } else {
-        return this.airtableList.filter(card => card.type === "press_release");
+        return this.airtableList.filter(
+          (card) => card.type === "press_release"
+        );
       }
-    }
+    },
   },
   data: () => ({
     airtableList: json.sort((a, b) => (a.date < b.date ? 1 : -1)),
-    toShow: "all"
+    toShow: "all",
   }),
   head() {
     return {
-      title: "News | Covid Watch"
+      title: "News | Covid Watch",
     };
-  }
+  },
 };
 </script>


### PR DESCRIPTION
### Summary

Introduce a new `MenuButton` component that is shared between the `AppBar` component and the news filters. News filtering buttons now look very similar to the style of the filters in the app bar.

### Screenshots
![image](https://user-images.githubusercontent.com/7595169/83345693-1d308000-a2cb-11ea-8100-5021b7f37f46.png)


![mobile view](https://user-images.githubusercontent.com/7595169/83345680-ed817800-a2ca-11ea-8da7-411fa45f1cd3.png)
