### PR TITLE
Blog footer

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -110,6 +110,11 @@ export default {
               href: "/news",
               nuxt: true,
             },
+            {
+              title: "Blog",
+              href: "https://medium.com/covid-watch",
+              nuxt: false,
+            },
           ],
         },
         {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -110,11 +110,6 @@ export default {
               href: "/news",
               nuxt: true,
             },
-            {
-              title: "Blog",
-              href: "https://medium.com/covid-watch",
-              nuxt: false,
-            },
           ],
         },
         {
@@ -123,6 +118,11 @@ export default {
             {
               title: "Privacy Policy",
               href: "/covid_watch_privacy_policy.pdf",
+              nuxt: false,
+            },
+            {
+              title: "Blog",
+              href: "https://medium.com/covid-watch",
               nuxt: false,
             },
           ],


### PR DESCRIPTION
Now that we have a Medium page, adding a link to it from our website in the footer.  I chose to put it under Resources to make the sections appear more balanced.  Originally had it under Organization but that looked visually unappealing bc it appeared unbalanced.

<img width="804" alt="Screen Shot 2020-06-30 at 4 12 38 PM" src="https://user-images.githubusercontent.com/16062590/86185952-ab379a80-bb05-11ea-8438-cbd580f4c3c1.png">
